### PR TITLE
Environment-dependent Config settings

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -3,7 +3,7 @@ import Section from 'grommet/components/Section';
 import Anchor from 'grommet/components/Anchor';
 import { Actions } from 'jumpstate';
 import { Link } from 'react-router-dom';
-import config from '../config';
+import { config } from '../config';
 
 // TODO: Look into grommet's path prop for buttons to see if it works with React-Router v4
 export default function Home() {
@@ -13,7 +13,7 @@ export default function Home() {
 
   return (
     <Section colorIndex="light-2">
-      <Anchor path="/astro" onClick={handleSettingProjectCollection.bind(null, config.dev.astroProjects)}>Introduction to Astronomy</Anchor>
+      <Anchor path="/astro" onClick={handleSettingProjectCollection.bind(null, config.astroProjects)}>Introduction to Astronomy</Anchor>
       <Anchor path="/" onClick={handleSettingProjectCollection.bind(null, [])}>Wildcam Darian: Labs</Anchor>
     </Section>
   );

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,46 @@
-const config = {
-  dev: {
-    panoptesAppId: '397e9bf4e29e75c0a092261ebe3338d3ef2687f2c5935d55c7ca0f63ecc2dd33', // test-rog project for dev
+/*
+Configuration Settings
+----------------------
+
+The config settings change depending on which environment the app is running in.
+By default, this is the development environment, but this can be changed either by:
+
+* An env query string, e.g. localhost:3998?env=production
+  (This changes the Panoptes JS Client does)
+* The NODE_ENV environment variable on the system running the app.
+
+ */
+
+var DEFAULT_ENV = 'development';
+var envFromBrowser = locationMatch(/\W?env=(\w+)/);
+var envFromShell = process.env.NODE_ENV;
+var env = envFromBrowser || envFromShell || DEFAULT_ENV;
+
+if (!env.match(/^(production|staging|development)$/)) {
+  throw new Error(`Error: Invalid Environment - ${envFromShell}`);
+}
+
+const baseConfig = {
+  'development': {
+    panoptesAppId: '397e9bf4e29e75c0a092261ebe3338d3ef2687f2c5935d55c7ca0f63ecc2dd33',
     astroProjects: ['1315']
   },
-  production: {
+  'production': {
     panoptesAppId: '',
     astroProjects: []
-  }
+  },
 };
+baseConfig.staging = baseConfig.development;
 
-export default config;
+const config = baseConfig[env];
+export { env, config };
+
+// Try and match the location.search property against a regex. Basically mimics
+// the CoffeeScript existential operator, in case we're not in a browser.
+function locationMatch(regex) {
+  var match;
+  if (typeof location !== 'undefined' && location !== null) {
+    match = location.search.match(regex);
+  }
+  return (match && match[1]) ? match[1] : undefined;
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 import oauth from 'panoptes-client/lib/oauth';
 
 import Main from './components/Main';
-import config from './config';
+import { config } from './config';
 import configureStore from './store';
 
 import './styles/main.styl';
@@ -15,7 +15,7 @@ const store = configureStore();
 const history = createHistory();
 
 // TODO: Make app ID dynamic between env
-oauth.init(config.dev.panoptesAppId)
+oauth.init(config.panoptesAppId)
   .then(() => {
     ReactDOM.render((
       <Provider store={store}>


### PR DESCRIPTION
## PR Overview
* This PR adds the ability for the app's `config` settings to change depending on the environment it's in.
  * e.g. instead of using `config.dev.foobar` to get the 'foobar' config value, we just need to use `config.foobar`
* We can manually switch the environment by passing a query string, e.g. `localhost:3998?env=production` - same concept as the Panoptes JavaScript client.

### Notes
* This code was based on the Panoptes JavaScript client - any suggestions for improvements are welcome.
* The switching supports three environments - production, development and staging - but...
  * [Quirk?] ...that last one might be a head-scratcher, given my recent problems with environmental variables. I can only run `npm start` when my `NODE_ENV` is set to `development`, yet when the app runs, the variable `process.env.NODE_ENV` has a value of `"staging"`. import { shrug, questionMark } from 'emojis'.
  * In any case, staging is the same as development, as far as the project is concerned.

### Status
Ready for review