### PR TITLE
Use hash history router instead of browser history

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "debounce": "~1.0.2",
     "grommet": "~1.5.0",
-    "history": "~4.6.3",
     "jumpstate": "^2.2.2",
     "panoptes-client": "~2.7.2",
     "prop-types": "~15.5.10",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Router, Route } from 'react-router-dom';
-import createHistory from 'history/createBrowserHistory';
+import { HashRouter as Router, Route } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import oauth from 'panoptes-client/lib/oauth';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -13,14 +12,13 @@ import configureStore from './store';
 import './styles/main.styl';
 
 const store = configureStore();
-const history = createHistory();
 
 // TODO: Make app ID dynamic between env
 oauth.init(config.panoptesAppId)
   .then(() => {
     ReactDOM.render((
       <Provider store={store}>
-        <Router history={history}>
+        <Router>
           <Route path="/" component={Main} />
         </Router>
       </Provider>),


### PR DESCRIPTION
This PR switches to React-Router v4's `HashRouter` component to use hash history instead of browser history. This is to make directly browsing to say `/#/astro` work in the browser. To get direct browsing to `/astro` with browser history working requires configuration setup with the server, which we could do, but I don't really see any reason to do that unless 100% clean urls are asked for. 