### PR TITLE
Switch back to BrowserRouter.

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { HashRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import oauth from 'panoptes-client/lib/oauth';
 import apiClient from 'panoptes-client/lib/api-client';


### PR DESCRIPTION
As discussed in slack and noted at https://github.com/zooniverse/rfc/issues/16#issuecomment-321005098, the app is reverting back to using browser history so that we can dynamically set the environment with a url query param. We'll need to configure our hosting server to be able to correctly route urls if directly browsed to. 