### PR TITLE
Classroom create form, improved styles, and copy link functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2237,6 +2237,14 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
       "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4="
     },
+    "copy-to-clipboard": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz",
+      "integrity": "sha512-c3GdeY8qxCHGezVb1EFQfHYK/8NZRemgcTIzPq7PuxjHAf/raKibn2QdhHPb/y6q74PMgH6yizaDZlRmw6QyKw==",
+      "requires": {
+        "toggle-selection": "1.0.6"
+      }
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -9916,6 +9924,15 @@
         "prop-types": "15.5.10"
       }
     },
+    "react-copy-to-clipboard": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.0.tgz",
+      "integrity": "sha1-I8zdfE2ewsx2ODnipVsSIK608z0=",
+      "requires": {
+        "copy-to-clipboard": "3.0.8",
+        "prop-types": "15.5.10"
+      }
+    },
     "react-deep-force-update": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz",
@@ -12043,6 +12060,11 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toposort": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "panoptes-client": "~2.7.2",
     "prop-types": "~15.5.10",
     "react": "~15.6.1",
+    "react-copy-to-clipboard": "~5.0.0",
     "react-dom": "~15.6.1",
     "react-redux": "~5.0.6",
     "react-router": "~4.1.2",

--- a/src/components/common/ClassroomCreateForm.jsx
+++ b/src/components/common/ClassroomCreateForm.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Form from 'grommet/components/Form';
+import FormField from 'grommet/components/FormField';
+import TextInput from 'grommet/components/TextInput';
+import Button from 'grommet/components/Button';
+import Heading from 'grommet/components/Heading';
+import Footer from 'grommet/components/Footer';
+
+// Subject, School, Description
+
+const ClassroomCreateForm = (props) => {
+  return (
+    <Form onSubmit={props.onSubmit}>
+      <Heading tag="h2">Create a Classroom</Heading>
+      <fieldset>
+        <FormField htmlFor="name" label="Name">
+          <TextInput id="name" placeholder="Name" />
+        </FormField>
+      </fieldset>
+      {props.optionalFormFields &&
+        <fieldset>
+          <FormField htmlFor="subject" label="Subject">
+            <TextInput id="subject" placeholder="Subject" />
+          </FormField>
+          <FormField htmlFor="school" label="School">
+            <TextInput id="school" placeholder="School" />
+          </FormField>
+          <FormField htmlFor="description" label="Description">
+            <TextInput id="description" placeholder="Description" />
+          </FormField>
+        </fieldset>}
+      <Footer>
+        <Button type="submit" label="Create" />
+      </Footer>
+    </Form>
+  );
+};
+
+ClassroomCreateForm.defaultProps = {
+  optionalFormFields: true,
+  onSubmit: () => {}
+};
+
+ClassroomCreateForm.propTypes = {
+  optionalFormFields: PropTypes.bool,
+  onSubmit: PropTypes.func
+};
+
+export default ClassroomCreateForm;

--- a/src/components/common/ClassroomManager.jsx
+++ b/src/components/common/ClassroomManager.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Actions } from 'jumpstate';
 import Box from 'grommet/components/Box';
 import Paragraph from 'grommet/components/Paragraph';
 import Button from 'grommet/components/Button';
 import Spinning from 'grommet/components/icons/Spinning';
 import Table from 'grommet/components/Table';
 import TableRow from 'grommet/components/TableRow';
+import Toast from 'grommet/components/Toast';
+import Anchor from 'grommet/components/Anchor';
+import Layer from 'grommet/components/Layer';
+import CopyToClipboard from 'react-copy-to-clipboard';
 import {
   CLASSROOMS_STATUS, CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
 import {
   ASSIGNMENTS_STATUS, ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
 } from '../../ducks/assignments';
+import ClassroomCreateFormContainer from '../../containers/common/ClassroomCreateFormContainer';
 
 const ClassroomManager = (props) => {
   return (
@@ -22,67 +28,109 @@ const ClassroomManager = (props) => {
       full={{ horizontal: true, vertical: false }}
       pad="large"
     >
-      <Box align="center" direction="row" justify="center">
+      <Box align="center" direction="row" justify="between">
         <Paragraph align="start" size="small">{props.classroomInstructions}</Paragraph>
-        <Button type="button" primary={true} label="Create New Classroom" onClick={props.onCreateNewClassroom} />
+        <Button type="button" primary={true} label="Create New Classroom" onClick={Actions.classrooms.setCreateFormVisibility} />
       </Box>
-      <Box>
-        {(props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.FETCHING) &&
-          <Spinning />}
-        {(props.classrooms.length > 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) &&
-          <Table className="classroom-manager__table"
-            summary="Your classrooms and linked assignments, assignment percentage completed, export data links, and assignment project links (row headings)"
-          >
-            <caption className="table__caption">Your Classrooms</caption>
-            <thead className="table__headers">
-              <TableRow>
-                <th id="assignments" scope="col"></th>
-                <th id="completed" scope="col">Completed</th>
-                <th id="export" scope="col">Export Data</th>
-                <th id="view-project" scope="col">View Project</th>
-              </TableRow>
-            </thead>
-            {props.classrooms.map((classroom) => {
-              // Can we get linked assignments with classrooms in single get request?
-              // No, if we want this, then we need to open an issue with the API
-              // TODO replace classifications_target with calculated percentage
-              return (
-                <tbody className="table__body" key={classroom.id}>
-                  <TableRow>
-                    <th className="table__row-header" id="classroom" colSpan="4" scope="colgroup">{classroom.name}</th>
-                  </TableRow>
-                  {(!props.assignments && props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING) &&
-                    <Spinning />}
-                  {(props.assignments[classroom.id] && props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
-                    props.assignments[classroom.id].map((assignment) => {
-                      return (
-                        <TableRow className="table__row-data" key={assignment.id}>
-                          <td headers="classroom assignments">{assignment.name}</td>
-                          <td headers="classroom completed">{assignment.metadata.classifications_target}</td>
-                          <td headers="classroom export">Export data link placeholder</td>
-                          <td headers="classroom view-project">project link placeholder</td>
-                        </TableRow>
-                      );
-                    })}
-                </tbody>
-              );
-            })}
-          </Table>}
-      </Box>
+      {props.showCreateForm &&
+        <Layer closer={true}>
+          <ClassroomCreateFormContainer />
+        </Layer>}
+      {props.toast && props.toast.message &&
+        <Toast status={props.toast.status ? props.toast.status : 'unknown'} onClose={props.resetToastState}>
+          {props.toast.message}
+        </Toast>}
+      {(props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.FETCHING) &&
+        <Spinning />}
+      {props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS &&
+        <Paragraph>No classrooms have been created yet.</Paragraph>}
+      {(props.classrooms.length > 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) &&
+        <Table className="manager-table">
+          <thead className="manager-table__headers">
+            <TableRow>
+              <th id="assignments" scope="col" className="manager-table__caption">Your Classrooms</th>
+              <th id="completed" scope="col" className="headers__header">Completed</th>
+              <th id="export" scope="col" className="headers__header">Export Data</th>
+              <th id="view-project" scope="col" className="headers__header">View Project</th>
+            </TableRow>
+          </thead>
+          {props.classrooms.map((classroom) => {
+            // TODO update URL once we have staging/production hosts
+            const joinURL = `https://${window.location.host}/students/classrooms/join?id=${classroom.id}&token=${classroom.joinToken}`;
+            // Can we get linked assignments with classrooms in single get request?
+            // No, if we want this, then we need to open an issue with the API
+            // TODO replace classifications_target with calculated percentage
+            return (
+              <tbody className="manager-table__body" key={classroom.id}>
+                <TableRow>
+                  <th className="manager-table__row-header" id="classroom" colSpan="4" scope="colgroup">
+                    {classroom.name}{' '}
+                    <CopyToClipboard text={joinURL} onCopy={props.copyJoinLink}>
+                      <Button type="button" className="manager-table__button--as-link" plain={true} onClick={() => {}}>
+                        Copy Join Link
+                      </Button>
+                    </CopyToClipboard>
+                  </th>
+                </TableRow>
+                {(!props.assignments && props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING) &&
+                  <Spinning />}
+                {(props.assignments[classroom.id] && props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
+                  props.assignments[classroom.id].map((assignment) => {
+                    return (
+                      <TableRow className="manager-table__row-data" key={assignment.id}>
+                        <td headers="classroom assignments">{assignment.name}</td>
+                        <td headers="classroom completed">{assignment.metadata.classifications_target}</td>
+                        <td headers="classroom export">
+                          <Button
+                            type="button"
+                            className="manager-table__button--as-link"
+                            plain={true}
+                            onClick={() => {}}
+                          >
+                            Export Data{' '}
+                            <i className="fa fa-arrow-down" aria-hidden="true"></i>
+                          </Button>
+                        </td>
+                        <td headers="classroom view-project">
+                          <Anchor
+                            className="manager-table__link"
+                            reverse={true}
+                            href="#"
+                          >
+                            Project Page{' '}
+                            <i className="fa fa-mail-forward" aria-hidden="true"></i>
+                          </Anchor>
+                        </td>
+                      </TableRow>
+                    );
+                  })}
+              </tbody>
+            );
+          })}
+        </Table>}
     </Box>
   );
 };
 
 ClassroomManager.defaultProps = {
   classroomInstructions: '',
+  copyJoinLink: () => {},
   onCreateNewClassroom: () => {},
+  resetToastState: () => {},
+  toast: null,
   ...CLASSROOMS_INITIAL_STATE,
   ...ASSIGNMENTS_INITIAL_STATE
 };
 
 ClassroomManager.propTypes = {
   classroomInstructions: PropTypes.string,
+  copyJoinLink: PropTypes.func,
   onCreateNewClassroom: PropTypes.func,
+  resetToastState: PropTypes.func,
+  toast: PropTypes.shape({
+    message: null,
+    status: null
+  }),
   ...CLASSROOMS_PROPTYPES,
   ...ASSIGNMENTS_PROPTYPES
 };

--- a/src/containers/common/ClassroomCreateFormContainer.jsx
+++ b/src/containers/common/ClassroomCreateFormContainer.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ClassroomCreateForm from '../../components/common/ClassroomCreateForm';
+
+class ClassroomCreateFormContainer extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <ClassroomCreateForm />
+    );
+  }
+}
+
+export default ClassroomCreateFormContainer;

--- a/src/containers/common/ClassroomManagerContainer.jsx
+++ b/src/containers/common/ClassroomManagerContainer.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import {
@@ -13,6 +12,16 @@ import ClassroomManager from '../../components/common/ClassroomManager';
 class ClassroomManagerContainer extends React.Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      toast: {
+        message: null,
+        status: null
+      }
+    };
+
+    this.copyJoinLink = this.copyJoinLink.bind(this);
+    this.resetToastState = this.resetToastState.bind(this);
   }
 
   componentDidMount() {
@@ -23,6 +32,14 @@ class ClassroomManagerContainer extends React.Component {
     });
   }
 
+  copyJoinLink() {
+    this.setState({ toast: { message: 'Link copied', status: 'ok' } });
+  }
+
+  resetToastState() {
+    this.setState({ toast: { message: null, status: null } });
+  }
+
   render() {
     return (
       <ClassroomManager
@@ -31,6 +48,10 @@ class ClassroomManagerContainer extends React.Component {
         classrooms={this.props.classrooms}
         classroomInstructions={this.props.classroomInstructions}
         classroomsStatus={this.props.classroomsStatus}
+        copyJoinLink={this.copyJoinLink}
+        resetToastState={this.resetToastState}
+        showCreateForm={this.props.showCreateForm}
+        toast={this.state.toast}
       />
     );
   }
@@ -50,7 +71,8 @@ const mapStateToProps = (state) => ({
   assignments: state.assignments.assignments,
   assignmentsStatus: state.assignments.status,
   classrooms: state.classrooms.classrooms,
-  classroomsStatus: state.classrooms.status
+  classroomsStatus: state.classrooms.status,
+  showCreateForm: state.classrooms.showCreateForm
 });
 
 export default connect(mapStateToProps)(ClassroomManagerContainer);

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -14,12 +14,14 @@ const CLASSROOMS_STATUS = {
 const CLASSROOMS_INITIAL_STATE = {
   classrooms: [],
   error: null,
+  showCreateForm: false,
   status: CLASSROOMS_STATUS.IDLE,
 };
 
 const CLASSROOMS_PROPTYPES = {
   classrooms: PropTypes.arrayOf(PropTypes.object),  //OPTIONAL TODO: Transform this into PropTypes.shape.
   error: PropTypes.object,
+  showCreateForm: PropTypes.bool,
   status: PropTypes.string,
 };
 
@@ -34,6 +36,10 @@ const setClassrooms = (state, classrooms) => {
 
 const setError = (state, error) => {
   return { ...state, error };
+};
+
+const setCreateFormVisibility = (state) => {
+  return { ...state, showCreateForm: !state.showCreateForm };
 };
 
 // Effects are for async actions and get automatically to the global Actions list
@@ -66,6 +72,7 @@ const classrooms = State('classrooms', {
   setStatus,
   setClassrooms,
   setError,
+  setCreateFormVisibility
 });
 
 export default classrooms;

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -7,6 +7,7 @@
     <meta name="description" content="zoo react boilerplate">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:300,400" rel="stylesheet">
+    <script src="https://use.fontawesome.com/1bf8b0c968.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/styles/components/classroom-manager.styl
+++ b/src/styles/components/classroom-manager.styl
@@ -1,20 +1,58 @@
 .classroom-manager
-  &__table
+  .manager-table
     background-color: white
     border: solid 2px #DEDEDE
 
-  .table
-    &__caption
-      bottom: -2.25em
+    &__link
+      color: #00969c !important
+      font-family: "Roboto Mono", monospace
+      font-size: 0.75em !important
       font-weight: bold
-      position: relative
-      text-align: left
+      letter-spacing: 1px
+      line-height: 1em
+
+      &:hover, &:focus
+        color: darken(#00969c, 40%) !important
+
+    &__caption
+      // bottom: -2.25em
+      font-size: 1.25em
+      font-weight: bold
+      padding: 11px 12px 11px 24px
+      // position: relative
+      // text-align: left
+
+    &__headers
+      .headers__header
+        font-family: "Roboto Mono", monospace
+        font-size: 0.75em
+        font-weight: bold
+        letter-spacing: 1px
+        text-transform: uppercase
+
+    &__button--as-link
+      border: none
+      color: #00969c !important
+      font-family: "Roboto Mono", monospace
+      font-size: 0.75em !important
+      font-weight: bold
+      letter-spacing: 1px
+      line-height: 1em
+
+      &:hover, &:focus
+        color: darken(#00969c, 40%) !important
 
     &__row-header
       background-color: GREY_5
       border-top: solid 2px #DEDEDE !important
       border-bottom: solid 2px #DEDEDE !important
+      font-family: "Roboto Mono", monospace
+      font-size: 0.9em
+      font-weight: bold
 
     &__row-data:not(:last-child)
       border-bottom: solid 2px #DEDEDE
+
+    .grommetux-table__table
+      margin: 0
 


### PR DESCRIPTION
What this PR does:
- A few improvements to the classroom management table to get closer to the design
- Copy link functionality for the classroom join link
- Adds the Toast grommet component to show success of copying the join link. This component could be used to notify success of classroom creation and other actions. It auto-closes on its own. This is instead of the Notification component which has to be dismissed and is much larger in visual space. I'm open to using either/or/both, so let me know your thoughts. 
- A non-functional UI for the classroom create form. You can view it by clicking on the "Create Classroom" button

This can all be tested by using zootester1 using production database. 

Next steps are more style improvements and making the create form functional.