### PR TITLE
Create form functionality and delete action

### DIFF
--- a/src/components/astro/AstroClassroomManager.jsx
+++ b/src/components/astro/AstroClassroomManager.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ClassroomManagerContainer from '../../containers/common/ClassroomManagerContainer';
 
 export default function AstroClassroomManager(props) {
-  const classroomInstructions = 'Share the classroom\'s unique join URL with your students to keep track of their progress as they work through each assignment. Share the URL under View Project with your students for them to complete the assignemnt.';
+  const classroomInstructions = 'First, make sure your students have set up a Zooniverse account. Then create a classroom and share the classroom\'s unique join URL with your students to keep track of their progress as they work through each assignment. Students must be logged in to their Zooniverse accounts first to be able to use the join link. Share the URL under View Project with your students for them to complete the assignment.';
   return (
     <ClassroomManagerContainer
       classroomInstructions={classroomInstructions}

--- a/src/components/common/ClassroomCreateForm.jsx
+++ b/src/components/common/ClassroomCreateForm.jsx
@@ -6,32 +6,59 @@ import TextInput from 'grommet/components/TextInput';
 import Button from 'grommet/components/Button';
 import Heading from 'grommet/components/Heading';
 import Footer from 'grommet/components/Footer';
-
-// Subject, School, Description
+import Paragraph from 'grommet/components/Paragraph';
 
 const ClassroomCreateForm = (props) => {
+  const optional = props.optionalFormFields;
   return (
-    <Form onSubmit={props.onSubmit}>
+    <Form onSubmit={props.onSubmit} pad="medium">
       <Heading tag="h2">Create a Classroom</Heading>
       <fieldset>
-        <FormField htmlFor="name" label="Name">
-          <TextInput id="name" placeholder="Name" />
+        <legend><Paragraph size="small">Input the class name and if applicable the section name</Paragraph></legend>
+        <FormField htmlFor="name" label="Name" help="required">
+          <TextInput
+            id="name"
+            placeHolder="Class name"
+            onDOMChange={props.onChange}
+            required={true}
+            value={props.fields.name}
+          />
         </FormField>
       </fieldset>
-      {props.optionalFormFields &&
-        <fieldset>
-          <FormField htmlFor="subject" label="Subject">
-            <TextInput id="subject" placeholder="Subject" />
-          </FormField>
-          <FormField htmlFor="school" label="School">
-            <TextInput id="school" placeholder="School" />
-          </FormField>
-          <FormField htmlFor="description" label="Description">
-            <TextInput id="description" placeholder="Description" />
-          </FormField>
-        </fieldset>}
+
+      <fieldset>
+        {optional &&
+          <legend><Paragraph size="small">Optional - Please fill out for Zooniverse to better understand who is using our education tools</Paragraph></legend>}
+        <FormField htmlFor="subject" label="Subject">
+          <TextInput
+            id="subject"
+            placeHolder="Class subject"
+            onDOMChange={props.onChange}
+            required={!optional}
+            value={props.fields.subject}
+          />
+        </FormField>
+        <FormField htmlFor="school" label="Institution">
+          <TextInput
+            id="school"
+            placeHolder="Name of institution or school"
+            onDOMChange={props.onChange}
+            required={!optional}
+            value={props.fields.school}
+          />
+        </FormField>
+        <FormField htmlFor="description" label="Description">
+          <textarea
+            id="description"
+            placeholder="Description of class"
+            onChange={props.onChange}
+            required={!optional}
+            value={props.fields.description}
+          />
+        </FormField>
+      </fieldset>
       <Footer>
-        <Button type="submit" label="Create" />
+        <Button type="submit" label="Create" primary={true} />
       </Footer>
     </Form>
   );
@@ -39,11 +66,25 @@ const ClassroomCreateForm = (props) => {
 
 ClassroomCreateForm.defaultProps = {
   optionalFormFields: true,
+  onChange: () => {},
+  fields: {
+    name: '',
+    subject: '',
+    school: '',
+    description: ''
+  },
   onSubmit: () => {}
 };
 
 ClassroomCreateForm.propTypes = {
   optionalFormFields: PropTypes.bool,
+  onChange: PropTypes.func,
+  fields: PropTypes.shape({
+    name: PropTypes.string,
+    subject: PropTypes.string,
+    school: PropTypes.string,
+    description: PropTypes.string
+  }),
   onSubmit: PropTypes.func
 };
 

--- a/src/components/common/ClassroomManager.jsx
+++ b/src/components/common/ClassroomManager.jsx
@@ -10,6 +10,7 @@ import TableRow from 'grommet/components/TableRow';
 import Toast from 'grommet/components/Toast';
 import Anchor from 'grommet/components/Anchor';
 import Layer from 'grommet/components/Layer';
+import CloseIcon from 'grommet/components/icons/base/Close';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import {
   CLASSROOMS_STATUS, CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
@@ -20,6 +21,7 @@ import {
 import ClassroomCreateFormContainer from '../../containers/common/ClassroomCreateFormContainer';
 
 const ClassroomManager = (props) => {
+  // TODO: Pagination for Classrooms
   return (
     <Box
       className="classroom-manager"
@@ -64,16 +66,25 @@ const ClassroomManager = (props) => {
               <tbody className="manager-table__body" key={classroom.id}>
                 <TableRow>
                   <th className="manager-table__row-header" id="classroom" colSpan="4" scope="colgroup">
-                    {classroom.name}{' '}
-                    <CopyToClipboard text={joinURL} onCopy={props.copyJoinLink}>
-                      <Button type="button" className="manager-table__button--as-link" plain={true} onClick={() => {}}>
-                        Copy Join Link
+                    <Box pad="none" margin="none" justify="between" direction="row">
+                      <span>
+                        {classroom.name}{' '}
+                        <CopyToClipboard text={joinURL} onCopy={props.copyJoinLink}>
+                          <Button type="button" className="manager-table__button--as-link" plain={true} onClick={() => {}}>
+                            Copy Join Link
+                          </Button>
+                        </CopyToClipboard>
+                      </span>
+                      <Button className="manager-table__button--delete" type="button" onClick={props.deleteClassroom.bind(null, classroom.id)}>
+                        <CloseIcon size="small" />
                       </Button>
-                    </CopyToClipboard>
+                    </Box>
                   </th>
                 </TableRow>
                 {(!props.assignments && props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING) &&
-                  <Spinning />}
+                  <TableRow className="manager-table__row-data">
+                    <td colSpan="4"><Spinning /></td>
+                  </TableRow>}
                 {(props.assignments[classroom.id] && props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
                   props.assignments[classroom.id].map((assignment) => {
                     return (

--- a/src/components/common/ClassroomManager.jsx
+++ b/src/components/common/ClassroomManager.jsx
@@ -33,7 +33,7 @@ const ClassroomManager = (props) => {
         <Button type="button" primary={true} label="Create New Classroom" onClick={Actions.classrooms.setCreateFormVisibility} />
       </Box>
       {props.showCreateForm &&
-        <Layer closer={true}>
+        <Layer closer={true} onClose={Actions.classrooms.setCreateFormVisibility}>
           <ClassroomCreateFormContainer />
         </Layer>}
       {props.toast && props.toast.message &&

--- a/src/containers/common/ClassroomCreateFormContainer.jsx
+++ b/src/containers/common/ClassroomCreateFormContainer.jsx
@@ -29,12 +29,18 @@ class ClassroomCreateFormContainer extends React.Component {
 
   onSubmit(event) {
     event.preventDefault();
+    // TODO: Add project id(s) associated to classroom create
     Actions.createClassroom(this.state.fields)
       .then(() => {
         Actions.classrooms.setCreateFormVisibility();
         if (this.props.projectCollection === config.astroProjects) {
           console.log('TODO: Auto create assignments for I2A');
-          // Actions.assignments.createAssignment()
+          // TODO: Actions.assignments.createAssignment().then(Actions.getClassroomsAndAssignments());
+          // For API optimization, we could merge the returned classroom into the local app state
+          // Then only call for the linked assignments for that one classroom
+          Actions.getClassroomsAndAssignments();
+        } else {
+          Actions.getClassroomsAndAssignments();
         }
       });
   }

--- a/src/containers/common/ClassroomCreateFormContainer.jsx
+++ b/src/containers/common/ClassroomCreateFormContainer.jsx
@@ -1,17 +1,67 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
 import ClassroomCreateForm from '../../components/common/ClassroomCreateForm';
+import { config } from '../../lib/config';
 
 class ClassroomCreateFormContainer extends React.Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      fields: {
+        name: '',
+        subject: '',
+        school: '',
+        description: ''
+      }
+    };
+
+    this.onSubmit = this.onSubmit.bind(this);
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange(event) {
+    const fields = { ...this.state.fields, [event.target.id]: event.target.value };
+    this.setState({ fields });
+  }
+
+  onSubmit(event) {
+    event.preventDefault();
+    Actions.createClassroom(this.state.fields)
+      .then(() => {
+        Actions.classrooms.setCreateFormVisibility();
+        if (this.props.projectCollection === config.astroProjects) {
+          console.log('TODO: Auto create assignments for I2A');
+          // Actions.assignments.createAssignment()
+        }
+      });
   }
 
   render() {
     return (
-      <ClassroomCreateForm />
+      <ClassroomCreateForm
+        fields={this.state.fields}
+        onChange={this.onChange}
+        onSubmit={this.onSubmit}
+      />
     );
   }
 }
 
-export default ClassroomCreateFormContainer;
+ClassroomCreateFormContainer.defaultProps = {
+  projectCollection: []
+};
+
+ClassroomCreateFormContainer.propTypes = {
+  projectCollection: PropTypes.arrayOf(PropTypes.string)
+};
+
+function mapStateToProps(state) {
+  return {
+    projectCollection: state.projectCollection
+  };
+}
+
+export default connect(mapStateToProps)(ClassroomCreateFormContainer);

--- a/src/containers/common/ClassroomManagerContainer.jsx
+++ b/src/containers/common/ClassroomManagerContainer.jsx
@@ -25,11 +25,7 @@ class ClassroomManagerContainer extends React.Component {
   }
 
   componentDidMount() {
-    Actions.getClassrooms().then(() => {
-      this.props.classrooms.forEach((classroom) => {
-        Actions.getAssignments(classroom.id);
-      });
-    });
+    Actions.getClassroomsAndAssignments();
   }
 
   copyJoinLink() {
@@ -38,6 +34,15 @@ class ClassroomManagerContainer extends React.Component {
 
   resetToastState() {
     this.setState({ toast: { message: null, status: null } });
+  }
+
+  deleteClassroom(id) {
+    // TODO: Add alert to ask if user is sure
+    Actions.deleteClassroom(id).then(() => {
+      // TODO: For API optimization, do we want to instead manually remove the classroom
+      // out of local app state instead of making another API call
+      Actions.getClassroomsAndAssignments();
+    });
   }
 
   render() {
@@ -49,6 +54,7 @@ class ClassroomManagerContainer extends React.Component {
         classroomInstructions={this.props.classroomInstructions}
         classroomsStatus={this.props.classroomsStatus}
         copyJoinLink={this.copyJoinLink}
+        deleteClassroom={this.deleteClassroom}
         resetToastState={this.resetToastState}
         showCreateForm={this.props.showCreateForm}
         toast={this.state.toast}

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -1,11 +1,13 @@
 import { State, Effect, Actions } from 'jumpstate';
 import PropTypes from 'prop-types';
-import { get, post } from '../lib/edu-api';
+import { get, post, httpDelete } from '../lib/edu-api';
 
 // Constants
 const CLASSROOMS_STATUS = {
   IDLE: 'idle',
   FETCHING: 'fetching',
+  POSTING: 'posting',
+  DELETING: 'deleting',
   SUCCESS: 'success',
   ERROR: 'error',
 };
@@ -65,20 +67,51 @@ Effect('getClassrooms', () => {
     .then((data) => {
       Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
       Actions.classrooms.setClassrooms(data);
+      return data;
     }).catch((error) => {
       handleError(error);
     });
 });
 
+Effect('getClassroomsAndAssignments', () => {
+  Actions.getClassrooms().then((classrooms) => {
+    classrooms.forEach((classroom) => {
+      // TODO: If many pages of assignments exist,
+      // loop through the number of pages to request all of the data
+      // and concatenate the response data together for the app state
+      // Neither Pagination nor infinite scroll would be good UX for current table design.
+      Actions.getAssignments(classroom.id);
+    });
+  });
+});
+
 Effect('createClassroom', (data) => {
+  Actions.classrooms.setStatus(CLASSROOMS_STATUS.POSTING);
+
   return post('teachers/classrooms/', data)
     .then((response) => {
-      if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
+      if (!response) { throw 'ERROR (ducks/classrooms/createClassroom): No response'; }
       if (response.ok &&
           response.body && response.body.data) {
-        Actions.getClassrooms();
+        return Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
       }
-      throw 'ERROR (ducks/classrooms/getClassrooms): Invalid response';
+      throw 'ERROR (ducks/classrooms/createClassroom): Invalid response';
+    })
+    .catch((error) => {
+      handleError(error);
+    });
+});
+
+Effect('deleteClassroom', (id) => {
+  Actions.classrooms.setStatus(CLASSROOMS_STATUS.DELETING);
+
+  return httpDelete(`teachers/classrooms/${id}`)
+    .then((response) => {
+      if (!response) { throw 'ERROR (ducks/classrooms/deleteClassroom): No response'; }
+      if (response.ok) {
+        return Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
+      }
+      throw 'ERROR (ducks/classrooms/deleteClassroom): Invalid response';
     })
     .catch((error) => {
       handleError(error);

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -1,6 +1,6 @@
 import { State, Effect, Actions } from 'jumpstate';
 import PropTypes from 'prop-types';
-import { get } from '../lib/edu-api';
+import { get, post } from '../lib/edu-api';
 
 // Constants
 const CLASSROOMS_STATUS = {
@@ -23,6 +23,13 @@ const CLASSROOMS_PROPTYPES = {
   error: PropTypes.object,
   showCreateForm: PropTypes.bool,
   status: PropTypes.string,
+};
+
+// Helper Functions
+function handleError(error) {
+  Actions.classrooms.setStatus(CLASSROOMS_STATUS.ERROR);
+  Actions.classrooms.setError(error);
+  console.error(error);
 };
 
 // Synchonous actions
@@ -59,9 +66,22 @@ Effect('getClassrooms', () => {
       Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
       Actions.classrooms.setClassrooms(data);
     }).catch((error) => {
-      Actions.classrooms.setStatus(CLASSROOMS_STATUS.ERROR);
-      Actions.classrooms.setError(error);
-      console.error(error);
+      handleError(error);
+    });
+});
+
+Effect('createClassroom', (data) => {
+  return post('teachers/classrooms/', data)
+    .then((response) => {
+      if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
+      if (response.ok &&
+          response.body && response.body.data) {
+        Actions.getClassrooms();
+      }
+      throw 'ERROR (ducks/classrooms/getClassrooms): Invalid response';
+    })
+    .catch((error) => {
+      handleError(error);
     });
 });
 

--- a/src/lib/edu-api.js
+++ b/src/lib/edu-api.js
@@ -17,4 +17,12 @@ export function get(endpoint, query) {
   return request.then(response => response);
 }
 
+export function post(endpoint, data) {
+  return superagent.post(`${config.root}${endpoint}`)
+    .set('Content-Type', 'application/json')
+    .set('Authorization', apiClient.headers.Authorization)
+    .send(data)
+    .then(response => response);
+}
+
 window.eduAPI = superagent;

--- a/src/lib/edu-api.js
+++ b/src/lib/edu-api.js
@@ -21,7 +21,14 @@ export function post(endpoint, data) {
   return superagent.post(`${config.root}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
-    .send(data)
+    .send({ data: { attributes: data } })
+    .then(response => response);
+}
+
+export function httpDelete(endpoint) {
+  return superagent.delete(`${config.root}${endpoint}`)
+    .set('Content-Type', 'application/json')
+    .set('Authorization', apiClient.headers.Authorization)
     .then(response => response);
 }
 

--- a/src/styles/components/classroom-manager.styl
+++ b/src/styles/components/classroom-manager.styl
@@ -53,6 +53,9 @@
     &__row-data:not(:last-child)
       border-bottom: solid 2px #DEDEDE
 
+    &__button--delete
+      border: none
+
     .grommetux-table__table
       margin: 0
 


### PR DESCRIPTION
This PR finishes the functionality for the create action as well as adds a delete button to the classroom list and the delete functionality.

- Improved UI for the create form modal
- A jumpstate Effect for getting classrooms and their linked assignments. This makes this sequence of API calls available to the whole app which is useful both for the delete method managed by the `ClassroomManagerContainer` and the create method managed by the `CreateClassroomFormContainer`.
- Related to the new Effect is a question about API usage optimization. We may want to consider alternatives to requesting for all classrooms again after create and delete. I left inline comments specifically about what I mean.
- Added `post` and `httpDelete` helper functions
