### PR TITLE
Wildcam Darien Map part 3: Download Button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1420,6 +1420,11 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-filesaver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.1.tgz",
+      "integrity": "sha1-HDUbL1dvWwDx0p1EIcTAQo7uX6E="
+    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/zooniverse/edu-api-front-end",
   "dependencies": {
+    "browser-filesaver": "1.1.1",
     "debounce": "~1.0.2",
     "grommet": "~1.5.0",
     "jumpstate": "^2.2.2",

--- a/src/components/common/SuperDownloadButton.jsx
+++ b/src/components/common/SuperDownloadButton.jsx
@@ -1,0 +1,118 @@
+/*
+SuperDownloadButton
+===================
+
+Creates a download button that opens the 'Save As' dialog box for downloading
+data. Across all browsers. Yes, including Safari 9, which has such poor HTML5
+support that it doesn't support 'download' in <a href="file.csv" download>.
+
+This component creates a hidden <form> that submits the data you want Safari to
+download to EduAPI's download service, which echoes the content back as a HTTP
+response with 'content-disposition' headers to force a download dialog.
+
+********************************************************************************
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { config } from '../../lib/config';
+import { blobbifyData, generateFilename } from '../../lib/mapexplorer-helpers'
+
+import { saveAs } from 'browser-filesaver';
+import superagent from 'superagent';
+
+import Button from 'grommet/components/Button';
+import Toast from 'grommet/components/Toast';
+import Label from 'grommet/components/Label';
+import SpinningIcon from 'grommet/components/icons/Spinning';
+import DownloadIcon from 'grommet/components/icons/base/Download';
+
+const STATUS = {
+  IDLE: 'idle',
+  FETCHING: 'fetching',
+  SUCCESS: 'success',
+  ERROR: 'error',
+};
+
+class SuperDownloadButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.download = this.download.bind(this);
+    
+    this.altForm = null;
+    this.altFormData = null;
+    
+    this.state = {  //Keep the state simple and local; no need for Redux connections.
+      status: STATUS.IDLE,
+    };
+  }
+
+  render() {
+    return (
+      <Button
+        className={this.props.className}
+        onClick={this.download}
+        icon={(this.state.status === STATUS.FETCHING) ? <SpinningIcon size="small" /> : this.props.icon}
+      >
+        <Label>{this.props.text}</Label>
+        {(this.state.status !== STATUS.SUCCESS) ? null : <Toast status='ok'>Success: file downloaded.</Toast> }
+        {(this.state.status !== STATUS.ERROR) ? null : <Toast status='critical'>Error: could not download the file.</Toast> }
+        <form style={{ 'display': 'none' }} action={config.root + 'downloads/'} method="POST" ref={c=>this.altForm=c} aria-hidden={true}>
+          <textarea name="data" ref={c=>this.altFormData=c} readOnly aria-label="alt-data" />
+          <input name="content_type" value={this.props.contentType} readOnly aria-label="alt-contenttype" />
+          <input name="filename" value={this.props.filename} readOnly aria-label="alt-filename" />
+        </form>
+      </Button>
+    );
+  }
+  
+  download() {
+    this.setState({ status: STATUS.FETCHING });
+    superagent.get(this.props.url)
+    .then(response => {
+      if (!response) { throw 'ERROR (SuperDownloadButton): No response'; }
+      if (response.ok && response.text) {  //Use .text, not .body, for pure CSV data
+        return response.text;
+      }
+      throw 'ERROR (SuperDownloadButton): invalid response';
+    })
+    .then(data => {
+      
+      const enableSafariWorkaround =
+        !(/Chrome/i.test(navigator.userAgent)) &&
+        /Safari/i.test(navigator.userAgent);
+      
+      if (enableSafariWorkaround) {
+        console.log('Downloading: Safari Workaround');
+        this.altFormData.value = data;
+        this.altForm.submit();
+      } else {
+        saveAs(blobbifyData(data, this.props.contentType), this.props.filename);
+      }
+      
+      this.setState({ status: STATUS.SUCCESS });
+    })
+    .catch(err => {
+      this.setState({ status: STATUS.ERROR });
+      console.error(err);
+    });
+  }
+}
+
+SuperDownloadButton.propTypes = {
+  url: PropTypes.string,
+  className: PropTypes.string,
+  text: PropTypes.string,
+  icon: PropTypes.node,
+  filename: PropTypes.string,
+  contentType: PropTypes.string,
+};
+SuperDownloadButton.defaultProps = { 
+  url: '',
+  className: '',
+  text: 'Download',
+  icon: <DownloadIcon size="small"/>,
+  filename: generateFilename(),
+  contentType: 'text/csv',
+};
+export default SuperDownloadButton;

--- a/src/components/common/SuperDownloadButton.jsx
+++ b/src/components/common/SuperDownloadButton.jsx
@@ -2,9 +2,17 @@
 SuperDownloadButton
 ===================
 
-Creates a download button that opens the 'Save As' dialog box for downloading
-data. Across all browsers. Yes, including Safari 9, which has such poor HTML5
-support that it doesn't support 'download' in <a href="file.csv" download>.
+Creates a download button that, when clicked, queries an external URL for data,
+then opens the 'Save As' dialog box for downloading said data.
+
+Usage:
+  <SuperDownloadButton
+    url="https://some.service.that/returns/csv"
+  />
+
+The "Super" part comes from the amount of work needed to get this working across
+all browsers, notably Safari 9, which has such poor HTML5 support that it
+doesn't support 'download' in <a href="file.csv" download>.
 
 This component creates a hidden <form> that submits the data you want Safari to
 download to EduAPI's download service, which echoes the content back as a HTTP

--- a/src/components/maps/MultiChoiceFilter.jsx
+++ b/src/components/maps/MultiChoiceFilter.jsx
@@ -36,7 +36,7 @@ class MultiChoicePanel extends React.Component {
                   onClick={()=>{
                     Actions.mapexplorer.removeFilterSelectionItem({ key: this.props.filterKey, value: item.value });
                   }}
-                  icon={<CheckboxSelectedIcon/>}
+                  icon={<CheckboxSelectedIcon size="small" />}
                 >
                   {item.label}
                 </Button>
@@ -50,7 +50,7 @@ class MultiChoicePanel extends React.Component {
                   onClick={()=>{
                     Actions.mapexplorer.addFilterSelectionItem({ key: this.props.filterKey, value: item.value });
                   }}
-                  icon={<CheckboxIcon/>}
+                  icon={<CheckboxIcon size="small" />}
                 >
                   {item.label}
                 </Button>

--- a/src/containers/maps/MapControls.jsx
+++ b/src/containers/maps/MapControls.jsx
@@ -19,6 +19,9 @@ import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
 import MultiChoiceFilter from '../../components/maps/MultiChoiceFilter';
+import SuperDownloadButton from '../../components/common/SuperDownloadButton';
+
+import { constructWhereClause } from '../../lib/mapexplorer-helpers'
 
 import {
   MAPEXPLORER_INITIAL_STATE, MAPEXPLORER_PROPTYPES
@@ -34,10 +37,24 @@ class MapControls extends React.Component {
   render() {
     if (!this.props.mapConfig) return null;
     
+    const mapConfig = this.props.mapConfig;
+    
+    const where = constructWhereClause(mapConfig, this.props.filters);
+    const downloadUrl = mapConfig.database.urls.csv.replace(
+      '{SQLQUERY}',
+      encodeURIComponent(mapConfig.database.queries.selectForDownload.replace('{WHERE}', where))
+    );
+    
     return (
       <Box className="map-controls">
-        {Object.keys(this.props.mapConfig.map.filters).map(key =>{
-          const item = this.props.mapConfig.map.filters[key];
+        <div>
+          <SuperDownloadButton
+            url={downloadUrl}
+          />
+        </div>
+        
+        {Object.keys(mapConfig.map.filters).map(key =>{
+          const item = mapConfig.map.filters[key];
           if (item.type === "multichoice") {
             return (
               <MultiChoiceFilter

--- a/src/ducks/mapexplorer.js
+++ b/src/ducks/mapexplorer.js
@@ -113,9 +113,9 @@ Effect('getMapMarkers', (payload = {}) => {
   
   Actions.mapexplorer.setMarkersStatus(MAPEXPLORER_MARKERS_STATUS.FETCHING);
   const where = constructWhereClause(mapConfig, selectedFilters);
-  const url = mapConfig.database.url.replace(
+  const url = mapConfig.database.urls.geojson.replace(
     '{SQLQUERY}',
-    mapConfig.database.queries.selectCameraCount.replace('{WHERE}', where)
+    encodeURIComponent(mapConfig.database.queries.selectCameraCount.replace('{WHERE}', where))
   );
   
   superagent.get(url)

--- a/src/lib/mapexplorer-helpers.js
+++ b/src/lib/mapexplorer-helpers.js
@@ -38,6 +38,27 @@ export function constructWhereClause(mapConfig, selectedFilters) {
   return sqlWhere;
 }
 
-function sqlString(str) {
+export function sqlString(str) {
   return str.replace(/'/ig, "''");
+}
+
+/*  Auto-generated a filename, for downloading purposes.
+ */
+export function generateFilename(basename = 'wildcam-', extension = '.csv') {
+  let timeString = new Date();
+  timeString =
+    timeString.getDate() +
+    ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][timeString.getMonth()] +
+    timeString.getFullYear();
+  return basename + timeString + extension;
+}
+
+/*  Transforms data into a blobby blob for downloading purposes.
+ */
+export function blobbifyData(data, contentType = 'text/csv') {
+  if (data) {
+    let dataBlob = new Blob([data], {type: contentType});
+    return dataBlob;
+  }
+  return null;
 }

--- a/src/lib/wildcam-darien.mapConfig.json
+++ b/src/lib/wildcam-darien.mapConfig.json
@@ -1,9 +1,13 @@
 {
   "database": {
-    "url": "http://wildcam-darien.carto.com/api/v2/sql?format=GeoJSON&q={SQLQUERY}",
+    "urls": {
+      "geojson": "http://wildcam-darien.carto.com/api/v2/sql?format=GeoJSON&q={SQLQUERY}",
+      "csv": "http://wildcam-darien.carto.com/api/v2/sql?format=CSV&q={SQLQUERY}"
+    },
     "queries": {
       "selectCameras": "SELECT * FROM cameras {WHERE}",
-      "selectCameraCount": "SELECT cam.*, COUNT(sbjagg.*) as count FROM cameras AS cam LEFT JOIN (SELECT sbj.camera, sbj.location, sbj.date, sbj.season, sbj.time_period, agg.data_choice, agg.subject_id FROM subjects AS sbj INNER JOIN aggregations AS agg ON sbj.subject_id = agg.subject_id) AS sbjagg ON cam.id = sbjagg.camera {WHERE} GROUP BY cam.cartodb_id ORDER BY count DESC"
+      "selectCameraCount": "SELECT cam.*, COUNT(sbjagg.*) as count FROM cameras AS cam LEFT JOIN (SELECT sbj.camera, sbj.location, sbj.date, sbj.season, sbj.time_period, agg.data_choice, agg.subject_id FROM subjects AS sbj INNER JOIN aggregations AS agg ON sbj.subject_id = agg.subject_id) AS sbjagg ON cam.id = sbjagg.camera {WHERE} GROUP BY cam.cartodb_id ORDER BY count DESC",
+      "selectForDownload": "SELECT cam.*, sbjagg.* FROM cameras AS cam INNER JOIN (SELECT sbj.camera, sbj.location, sbj.month, sbj.year, sbj.season, sbj.time_period, sbj.time, sbj.date, sbj.darien_id, agg.data_choice, agg.data_answers_howmany_1, agg.data_answers_howmany_2, agg.data_answers_howmany_3, agg.data_answers_howmany_4, agg.data_answers_howmany_5, agg.data_answers_howmany_6, agg.data_answers_howmany_7, agg.data_answers_howmany_8, agg.data_answers_howmany_9, agg.data_answers_howmany_10, agg.data_answers_howmany_1120, agg.data_answers_howmany_21 FROM subjects AS sbj INNER JOIN aggregations AS agg ON sbj.subject_id = agg.subject_id) AS sbjagg ON cam.id = sbjagg.camera {WHERE}"
     }
   },
   "map": {


### PR DESCRIPTION
## PR Overview
* This PR adds the ability for users to download the data they're viewing on the map (i.e. with whatever species/habitat/etc filters they've selected) as a CSV file.
* Notably, this is done using the new `SuperDownloadButton` component, which basically rips off most of the code from WildCam Gorongosa to make it functional across all browsers.
  * Yes, especially Safari, which was such a strong requirement that we had to make a wonky echo-ing workaround using the EduAPI.
  * That said, the SuperDownloadButton does less work this time round, as it doesn't need to convert GeoJSON data into CSV as it previously did. (The Carto API handles that this time, woo) 

![screen shot 2017-08-22 at 20 16 24](https://user-images.githubusercontent.com/13952701/29583070-cda825f0-8776-11e7-88b5-eab4f4c9cd5b.png)

### Matters of (Mild?) Concern
* The `<SuperDownloadButton>` is bizarre in that it crams multiple sub-elements into a Grommet `<Button>` and I'm not entirely sure how comfortable that is within the Grommet framework. I mean it works, technically, but hmm... 
* The rationale for cramming everything into a single Grommet `<Button>` is to maintain the succinctness of the Grommet layout... i.e. I didn't want to wrap everything in a superfluous `<span>`
* ...but it now has the unfortunate side effect of not making the button look like a button... (no borders, if you notice)

In any case, I'm always open to layout/style suggestions.

### Status
Merging, go!