### PR TITLE
Manual Deploy Script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -364,6 +364,25 @@
         "postcss-value-parser": "3.3.0"
       }
     },
+    "aws-sdk": {
+      "version": "2.1.50",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.50.tgz",
+      "integrity": "sha1-Zd3CuEDmkCEIftNfKC1jKgUpShs=",
+      "dev": true,
+      "requires": {
+        "sax": "0.5.3",
+        "xml2js": "0.2.8",
+        "xmlbuilder": "0.4.2"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz",
+          "integrity": "sha1-N3NxSg2RV8qqcwKXHvpcbc2lUtY=",
+          "dev": true
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -2952,6 +2971,19 @@
         "buffer-indexof": "1.1.0"
       }
     },
+    "docco": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/docco/-/docco-0.6.3.tgz",
+      "integrity": "sha1-xHtYI9eVY9b8Or1J895ImG5VIu4=",
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "fs-extra": "4.0.1",
+        "highlight.js": "9.12.0",
+        "marked": "0.3.6",
+        "underscore": "1.8.3"
+      }
+    },
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
@@ -4405,6 +4437,17 @@
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
+      "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "3.0.1",
+        "universalify": "0.1.1"
+      }
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -6100,6 +6143,12 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+      "dev": true
+    },
     "history": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/history/-/history-4.6.3.tgz",
@@ -6400,6 +6449,31 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "dev": true
+    },
+    "iced-coffee-script": {
+      "version": "1.8.0-e",
+      "resolved": "https://registry.npmjs.org/iced-coffee-script/-/iced-coffee-script-1.8.0-e.tgz",
+      "integrity": "sha1-6dPhe4cPyoF5/Q9iVOJ2GvzloTY=",
+      "dev": true,
+      "requires": {
+        "docco": "0.6.3",
+        "iced-runtime": "1.0.3",
+        "mkdirp": "0.3.5"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+          "dev": true
+        }
+      }
+    },
+    "iced-runtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/iced-runtime/-/iced-runtime-1.0.3.tgz",
+      "integrity": "sha1-LU9PuZmreqVDCxk8d6f85BGDGc4=",
       "dev": true
     },
     "iconv-lite": {
@@ -7327,6 +7401,15 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -7949,6 +8032,12 @@
         "remark-parse": "3.0.1",
         "unified": "6.1.5"
       }
+    },
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "dev": true
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -9799,6 +9888,71 @@
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
         "randombytes": "2.0.5"
+      }
+    },
+    "publisssh": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/publisssh/-/publisssh-1.1.0.tgz",
+      "integrity": "sha1-GFQZZA8MuF2ZPJhD+xP/fmbsBIo=",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "2.1.50",
+        "chalk": "0.5.1",
+        "iced-coffee-script": "1.8.0-e",
+        "mime": "1.3.4",
+        "optimist": "0.6.1",
+        "wrench": "1.5.9"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        }
       }
     },
     "punycode": {
@@ -12259,6 +12413,12 @@
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
     },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
     "unherit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
@@ -12330,6 +12490,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.1.3.tgz",
       "integrity": "sha1-7CaOcxudJ3p5pbWqBkOZDkBdYAs="
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -13071,6 +13237,12 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "wrench": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
+      "integrity": "sha1-QRaRxjqbJTGxcAJnJ5veyiOyFCo=",
+      "dev": true
+    },
     "write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
@@ -13116,6 +13288,29 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+      "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+      "dev": true,
+      "requires": {
+        "sax": "0.5.8"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
+          "dev": true
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
+      "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M=",
       "dev": true
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js $(find src -name *.spec.jsx) --compilers js:babel-core/register --require mock-local-storage || true",
     "eslint": "eslint .",
     "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
-    "deploy-production": "NODE_ENV=production npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
+    "deploy-production": "NODE_ENV=production BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p && publisssh dist zooniverse-static/classroom.zooniverse.org"
   },
   "engines": {
     "node": "^8.1.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack-dev-server --config ./webpack.config.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js $(find src -name *.spec.jsx) --compilers js:babel-core/register --require mock-local-storage || true",
     "eslint": "eslint .",
-    "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p"
+    "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
+    "deploy-production": "NODE_ENV=production npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
   },
   "engines": {
     "node": "^8.1.2",
@@ -77,6 +78,7 @@
     "mocha": "~3.4.2",
     "mock-local-storage": "~1.0.4",
     "nib": "~1.1.2",
+    "publisssh": "^1.1.0",
     "react-hot-loader": "~3.0.0-beta.7",
     "react-test-renderer": "~15.6.1",
     "rimraf": "~2.6.1",

--- a/src/components/astro/AstroHome.jsx
+++ b/src/components/astro/AstroHome.jsx
@@ -13,11 +13,13 @@ import Button from 'grommet/components/Button';
 import Paragraph from 'grommet/components/Paragraph';
 import Anchor from 'grommet/components/Anchor';
 
+import backgroundImageUrl from '../../images/background.jpg'
+
 import AstroHomeSignedIn from './AstroHomeSignedIn';
 
 const AstroHome = (props) => {
   const signedIn = (props.user && props.initialised);
-  const backgroundImage = <Image alt="" src="/images/background.jpg" fit="cover" align={{ bottom: true }} />;
+  const backgroundImage = <Image alt="" src={backgroundImageUrl} fit="cover" align={{ bottom: true }} />;
 
   return (
     <Article className="home" colorIndex="accent-3">

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -45,7 +45,7 @@ module.exports = {
   ],
 
   resolve: {
-    extensions: ['.js', '.jsx', '.styl', '.css'],
+    extensions: ['.js', '.jsx', '.styl', '.css', '.json'],
     modules: ['.', 'node_modules'],
   },
 
@@ -56,8 +56,7 @@ module.exports = {
       use: 'babel-loader',
     }, {
       test: /\.css$/,
-      use: ExtractTextPlugin.extract({
-        fallback: 'style-loader',
+      use: ['style-loader', {
         loader: 'css-loader',
         options: {
           includePaths: [
@@ -65,7 +64,7 @@ module.exports = {
             path.resolve(__dirname, 'node_modules/zooniverse-react-components/lib')
           ]
         }
-      }),
+      }]
     }, {
       test: /\.styl$/,
       use: ExtractTextPlugin.extract({


### PR DESCRIPTION
### Context
* Thanks to Adam, we now have a production-ready site at https://classroom.zooniverse.org
* classroomS.zooniverse.org will also redirect to the site.
* There are NO auto-deploys for this project. (At least not in this phase.)
* The S3 bucket is `zooniverse-static/classroom.zooniverse.org`
* There will be NO URL rewriting, (e.g. no classroom.zooniverse.org/astro) since we're using hash routing (e.g. classroom.zooniverse.org/#/astro). We may revisit this in the future, but for now this is how we're rolling, up for launch.
* As with most PJC-using projects, we can switch environments using `?env=production`

## PR Overview
* This PR allows us to manually deploy our project to classroom.zooniverse.org using `npm run deploy-production`
* It works. Mostly? Kinda?
* I mean, https://classroom.zooniverse.org now has our code and it mostly works fine, but...

### OH MY GOD SO MANY PROBLEMS
There have been inexplicable problems in this process. Here's the list of known WTFs.

1. Issues with `webpack.production.config.js`
  * I'm not sure if we saw problems with this before, but prior to this PR, running `npm run build` caused a derpload of errors.
  * Fixes needed:
    * [simple] I added `.json` to the list of extensions to resolve.
    * **[perplexing]** The existence of `ExtractTextPlugin.extract({args})` caused the build process to shout out, `loader option has been deprecated - replace with "use"`, which I assume means that the `{args}` object needed to be structured in a specific way. I couldn't figure out what that structure would be, so I temporarily removed ExtractTextPlugin.
2. 💀  [major] https://classroom.zooniverse.org thinks it's **staging**
  * I don't know what's up, but despite explicitly stating NODE_ENV and BABEL_ENV in `"deploy-production": "NODE_ENV=production BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p && publisssh dist zooniverse-static/classroom.zooniverse.org"`, the website that's built & deployed still thinks it's on staging/development.
  * You can switch environments by going to https://classroom.zooniverse.org/?env=staging, but that's not the default behaviour we want.
  * I have no idea what's up. Help!
3. `npm run deploy-production` is unnecessarily long and duplicates `npm run build`
  * I initially tried doing...
```
"build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
"deploy-production": "NODE_ENV=production BABEL_ENV=production npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
   },
```
  * ...but that mysteriously causes the `build` script to no longer recognise ES6 script. ("What is this ellipsis in `{...object}` ?", the compiler asks, with incredulity in its voice.) 
4. [not-really-a-problem-but-] We're using `publisssh` to publish.
  * I'm sure there are better solutions out there, but unfortunately I don't have time at the moment to research what they are. I'd like to revisit this again soon.
  * `publisssh` is the solution currently being used by our nearest evolutionary cousin, liberating-the-liberator/Anti-Slavery Manuscripts, so I thought it's functional enough for EAPIFE for launch day.

### Status
Merging and deploying.

The deployment script's functional - in the sense that it populates classroom.zooniverse.org with the website we've built - but there are so many gotchas that need to be solved. This will need to be revisited, but for now, we need a basic deploy script so our non-dev project stakeholders can review the project before launch.