### PR TITLE
Export env variables. Add plugin to babel production env.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
       "presets": [
         ["es2015", { "modules": false }],
         "react"
-      ]
+      ],
+      "plugins": ["transform-object-rest-spread"]
     },
     "test": {
       "presets": ["es2015", "react"],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js $(find src -name *.spec.jsx) --compilers js:babel-core/register --require mock-local-storage || true",
     "eslint": "eslint .",
     "build": "export BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
-    "deploy-production": "export NODE_ENV=production npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
+    "deploy-production": "export NODE_ENV=production; npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
   },
   "engines": {
     "node": "^8.1.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "start": "BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack-dev-server --config ./webpack.config.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js $(find src -name *.spec.jsx) --compilers js:babel-core/register --require mock-local-storage || true",
     "eslint": "eslint .",
-    "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
-    "deploy-production": "NODE_ENV=production BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p && publisssh dist zooniverse-static/classroom.zooniverse.org"
+    "build": "export BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
+    "deploy-production": "export NODE_ENV=production npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
   },
   "engines": {
     "node": "^8.1.2",


### PR DESCRIPTION
For #34  (maybe fix?)

I haven't actually tried the deployment, but the build looks good.
- ExtractTextPlugin isn't needed for the css-loader configuration because the css files are imported into the main.styl file which is then transpiled by the stylus configuration and that will handle extraction to main.css. I think this is something that needs fixing in zoo-reduxify too.
- I fixed the environment variable exports in the npm scripts. I added the export command so that the variable is put into your bash profile. Not sure if this will fix the production env when deployed since I didn't try that. But I noticed that now the webpack configuration file seems to be correctly running in production with the build task.
- I removed the redundant script in the deployment script and calling `npm run build` instead.
- Added the transform-object-rest-spread to babel production so that it knows how to transpile that for the production build.