### PR TITLE
WildCam Darien Map part 7: Regions

### DIFF
--- a/src/components/maps/MultiChoiceFilter.jsx
+++ b/src/components/maps/MultiChoiceFilter.jsx
@@ -11,58 +11,52 @@ import CheckboxSelectedIcon from 'grommet/components/icons/base/CheckboxSelected
 
 import { ZooTran } from '../../lib/zooniversal-translator.js';
 
-class MultiChoicePanel extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-  
-  render() {
-    return (
-      <Box className="multi-choice filter">
-        <Label align="end" margin="none" size="small">
-          {(this.props.selected && this.props.selected.length > 0)
-            ? `${this.props.selected.length} / ${this.props.options.length} ${ZooTran('options selected')}`
-            : ZooTran('Showing all options')
+const MultiChoicePanel = (props) => {
+  return (
+    <Box className="multi-choice filter">
+      <Label align="end" margin="none" size="small">
+        {(props.selected && props.selected.length > 0)
+          ? `${props.selected.length} / ${props.options.length} ${ZooTran('options selected')}`
+          : ZooTran('Showing all options')
+        }
+      </Label>
+      <Box>
+        {props.options && props.options.map(item => {
+          const isSelected = props.selected && props.selected.indexOf(item.value) >= 0;
+
+          if (isSelected) {
+
+            return (
+              <Button
+                key={`map-control-filter-item-${props.filterKey}-${item.value}`}
+                onClick={()=>{
+                  Actions.mapexplorer.removeFilterSelectionItem({ key: props.filterKey, value: item.value });
+                }}
+                icon={<CheckboxSelectedIcon size="small" />}
+              >
+                {ZooTran(item.label)}
+              </Button>
+            );
+
+          } else {
+
+            return (
+              <Button
+                key={`map-control-filter-item-${props.filterKey}-${item.value}`}
+                onClick={()=>{
+                  Actions.mapexplorer.addFilterSelectionItem({ key: props.filterKey, value: item.value });
+                }}
+                icon={<CheckboxIcon size="small" />}
+              >
+                {ZooTran(item.label)}
+              </Button>
+            );
+
           }
-        </Label>
-        <Box>
-          {this.props.options && this.props.options.map(item => {
-            const isSelected = this.props.selected && this.props.selected.indexOf(item.value) >= 0;
-
-            if (isSelected) {
-
-              return (
-                <Button
-                  key={`map-control-filter-item-${this.props.filterKey}-${item.value}`}
-                  onClick={()=>{
-                    Actions.mapexplorer.removeFilterSelectionItem({ key: this.props.filterKey, value: item.value });
-                  }}
-                  icon={<CheckboxSelectedIcon size="small" />}
-                >
-                  {ZooTran(item.label)}
-                </Button>
-              );
-
-            } else {
-
-              return (
-                <Button
-                  key={`map-control-filter-item-${this.props.filterKey}-${item.value}`}
-                  onClick={()=>{
-                    Actions.mapexplorer.addFilterSelectionItem({ key: this.props.filterKey, value: item.value });
-                  }}
-                  icon={<CheckboxIcon size="small" />}
-                >
-                  {ZooTran(item.label)}
-                </Button>
-              );
-
-            }
-          })}
-        </Box>
+        })}
       </Box>
-    );
-  }
+    </Box>
+  );
 }
 
 MultiChoicePanel.defaultProps = {

--- a/src/components/maps/SimpleMapLegend.jsx
+++ b/src/components/maps/SimpleMapLegend.jsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Box from 'grommet/components/Box';
+import List from 'grommet/components/List';
+import ListItem from 'grommet/components/ListItem';
 
 const SimpleMapLegend = (props) => {
   return (
-    <Box className="map-legend-simple">
+    <List className="map-legend-simple">
       {Object.keys(props.items).map(key => {
         const value = props.items[key];
         return (
-          <Box className="map-legend-item" key={`map-legend-item-${key}`} direction="row">
+          <ListItem className="map-legend-item" key={`map-legend-item-${key}`} direction="row">
             <svg height="10" width="10"><circle cx="5" cy="5" r="5" fill={key} fillOpacity="0.5" /></svg> <span>{value}</span>
-          </Box>
+          </ListItem>
         );
       })}
-    </Box>
+    </List>
   );
 }
 

--- a/src/components/maps/SimpleMapLegend.jsx
+++ b/src/components/maps/SimpleMapLegend.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import List from 'grommet/components/List';
 import ListItem from 'grommet/components/ListItem';
 
+import { ZooTran } from '../../lib/zooniversal-translator.js';
+
 const SimpleMapLegend = (props) => {
   return (
     <List className="map-legend-simple">
@@ -10,7 +12,7 @@ const SimpleMapLegend = (props) => {
         const value = props.items[key];
         return (
           <ListItem className="map-legend-item" key={`map-legend-item-${key}`} direction="row">
-            <svg height="10" width="10"><circle cx="5" cy="5" r="5" fill={key} fillOpacity="0.5" /></svg> <span>{value}</span>
+            <svg height="10" width="10"><circle cx="5" cy="5" r="5" fill={key} fillOpacity="0.5" /></svg> <span>{ZooTran(value)}</span>
           </ListItem>
         );
       })}

--- a/src/components/maps/SimpleMapLegend.jsx
+++ b/src/components/maps/SimpleMapLegend.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Box from 'grommet/components/Box';
+
+const SimpleMapLegend = (props) => {
+  return (
+    <Box className="map-legend-simple">
+      {Object.keys(props.items).map(key => {
+        const value = props.items[key];
+        return (
+          <Box className="map-legend-item" key={`map-legend-item-${key}`} direction="row">
+            <svg height="10" width="10"><circle cx="5" cy="5" r="5" fill={key} fillOpacity="0.5" /></svg> <span>{value}</span>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+
+SimpleMapLegend.defaultProps = {
+  items: {},
+};
+SimpleMapLegend.propTypes = {
+  items: PropTypes.object,
+};
+
+export default SimpleMapLegend;

--- a/src/containers/maps/MapVisuals.jsx
+++ b/src/containers/maps/MapVisuals.jsx
@@ -12,10 +12,12 @@ This feature has one function:
  */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
+import SimpleMapLegend from '../../components/maps/SimpleMapLegend';
 import Box from 'grommet/components/Box';
 
 import L from 'leaflet';
@@ -96,7 +98,7 @@ class MapVisuals extends React.Component {
       : [];
     
     const geomapLayers = {};
-    extraLayers.map(item => {
+    extraLayers.map(item => {  //TODO: Maybe move this to an external duck?
       geomapLayers[item.label] = L.geoJson(null, { style: item.style }).addTo(this.map);
       
       const url = this.props.mapConfig.database.urls.geojson.replace('{SQLQUERY}', encodeURIComponent(item.query));
@@ -119,6 +121,23 @@ class MapVisuals extends React.Component {
       });
     });
     //--------------------------------
+    
+    //Add a map legend, if applicable.
+    //--------------------------------
+    if (this.props.mapConfig.map && this.props.mapConfig.map.legend) {
+      if (this.props.mapConfig.map.legend.type === 'simple') {
+        const legend = L.control({position: 'bottomleft'});
+        legend.onAdd = (map) => {
+          let div = L.DomUtil.create('div', 'map-legend');
+          ReactDOM.render(<SimpleMapLegend items={this.props.mapConfig.map.legend.items} />, div);
+          return div;
+        };
+        legend.addTo(this.map);
+        
+      }
+    }
+    //--------------------------------
+    
     
     //Add standard 'Layer' controls
     //--------------------------------

--- a/src/containers/maps/MapVisuals.jsx
+++ b/src/containers/maps/MapVisuals.jsx
@@ -111,7 +111,8 @@ class MapVisuals extends React.Component {
       .then(geojson => {
         if (!geomapLayers[item.label]) return;
         geomapLayers[item.label].clearLayers();
-        geomapLayers[item.label].addData(geojson);  //Markers Data must be in GeoJSON format.
+        geomapLayers[item.label].addData(geojson);
+        this.dataLayer && this.dataLayer.bringToFront();  //Always keep the data layer at the forefront.
       })
       .catch(err => {
         console.error(err);

--- a/src/containers/maps/MapVisuals.jsx
+++ b/src/containers/maps/MapVisuals.jsx
@@ -92,16 +92,34 @@ class MapVisuals extends React.Component {
     //Prepare additional geographic information layers (park boundaries, etc)
     //--------------------------------
     const extraLayers = {
-      'national_park': {
-        'label': 'National Parks',
+      'darien_national_park': {
+        'label': 'Darien National Parks',
         'query': 'SELECT * FROM darien_national_park',
-      }
+        'style': function (feature) {
+          return {
+            stroke: true,
+            color: '#3cc',
+            fill: false,
+          };
+        },
+      },
+      'soberania_national_park': {
+        'label': 'Soberania National Parks',
+        'query': 'SELECT * FROM soberania_national_park',
+        'style': function (feature) {
+          return {
+            stroke: true,
+            color: '#3cc',
+            fill: false,
+          };
+        },
+      },
     };
     
     const geomapLayers = {};
     Object.keys(extraLayers).map(key => {
       const item = extraLayers[key];
-      geomapLayers[item.label] = L.geoJson(null).addTo(this.map);
+      geomapLayers[item.label] = L.geoJson(null, { style: item.style }).addTo(this.map);
       
       const url = this.props.mapConfig.database.urls.geojson.replace('{SQLQUERY}', encodeURIComponent(item.query));
       superagent.get(url)
@@ -128,7 +146,7 @@ class MapVisuals extends React.Component {
     //--------------------------------
     L.control.layers(tileLayers, {
       'Data': this.dataLayer,
-      ...geomapLayers
+      ...geomapLayers,
     }, {
       position: 'topleft',
       collapsed: true,

--- a/src/containers/maps/MapVisuals.jsx
+++ b/src/containers/maps/MapVisuals.jsx
@@ -91,34 +91,12 @@ class MapVisuals extends React.Component {
     
     //Prepare additional geographic information layers (park boundaries, etc)
     //--------------------------------
-    const extraLayers = {
-      'darien_national_park': {
-        'label': 'Darien National Parks',
-        'query': 'SELECT * FROM darien_national_park',
-        'style': function (feature) {
-          return {
-            stroke: true,
-            color: '#3cc',
-            fill: false,
-          };
-        },
-      },
-      'soberania_national_park': {
-        'label': 'Soberania National Parks',
-        'query': 'SELECT * FROM soberania_national_park',
-        'style': function (feature) {
-          return {
-            stroke: true,
-            color: '#3cc',
-            fill: false,
-          };
-        },
-      },
-    };
+    const extraLayers = (this.props.mapConfig.map && this.props.mapConfig.map.extraLayers)
+      ? this.props.mapConfig.map.extraLayers
+      : [];
     
     const geomapLayers = {};
-    Object.keys(extraLayers).map(key => {
-      const item = extraLayers[key];
+    extraLayers.map(item => {
       geomapLayers[item.label] = L.geoJson(null, { style: item.style }).addTo(this.map);
       
       const url = this.props.mapConfig.database.urls.geojson.replace('{SQLQUERY}', encodeURIComponent(item.query));
@@ -138,7 +116,6 @@ class MapVisuals extends React.Component {
       .catch(err => {
         console.error(err);
       });
-      
     });
     //--------------------------------
     

--- a/src/containers/maps/MapVisuals.jsx
+++ b/src/containers/maps/MapVisuals.jsx
@@ -22,6 +22,7 @@ import Box from 'grommet/components/Box';
 
 import L from 'leaflet';
 import superagent from 'superagent';
+import { ZooTran } from '../../lib/zooniversal-translator.js';
 
 import {
   MAPEXPLORER_INITIAL_STATE, MAPEXPLORER_PROPTYPES
@@ -74,7 +75,7 @@ class MapVisuals extends React.Component {
     const tileLayers = {};
     this.props.mapConfig.map.tileLayers.map((layer, index) => {
       const tl = L.tileLayer(layer.url, { attribution: layer.attribution, });
-      tileLayers[layer.name] = tl;
+      tileLayers[ZooTran(layer.name)] = tl;
       if (index === 0) tl.addTo(this.map);  //Use the first tile layer as the default tile layer.
     });
     //--------------------------------

--- a/src/containers/maps/MapVisuals.jsx
+++ b/src/containers/maps/MapVisuals.jsx
@@ -100,7 +100,7 @@ class MapVisuals extends React.Component {
     
     const geomapLayers = {};
     extraLayers.map(item => {  //TODO: Maybe move this to an external duck?
-      geomapLayers[item.label] = L.geoJson(null, { style: item.style }).addTo(this.map);
+      geomapLayers[ZooTran(item.label)] = L.geoJson(null, { style: item.style }).addTo(this.map);
       
       const url = this.props.mapConfig.database.urls.geojson.replace('{SQLQUERY}', encodeURIComponent(item.query));
       superagent.get(url)
@@ -112,9 +112,9 @@ class MapVisuals extends React.Component {
         throw 'ERROR (MapVisuals/getExtraLayers): invalid response';
       })
       .then(geojson => {
-        if (!geomapLayers[item.label]) return;
-        geomapLayers[item.label].clearLayers();
-        geomapLayers[item.label].addData(geojson);
+        if (!geomapLayers[ZooTran(item.label)]) return;
+        geomapLayers[ZooTran(item.label)].clearLayers();
+        geomapLayers[ZooTran(item.label)].addData(geojson);
         this.dataLayer && this.dataLayer.bringToFront();  //Always keep the data layer at the forefront.
       })
       .catch(err => {
@@ -142,10 +142,11 @@ class MapVisuals extends React.Component {
     
     //Add standard 'Layer' controls
     //--------------------------------
-    L.control.layers(tileLayers, {
-      'Data': this.dataLayer,
-      ...geomapLayers,
-    }, {
+    let controllableLayers = {};
+    controllableLayers[ZooTran('Cameras')] = this.dataLayer;
+    controllableLayers = { ...controllableLayers, ...geomapLayers };
+    
+    L.control.layers(tileLayers, controllableLayers, {
       position: 'topleft',
       collapsed: true,
     }).addTo(this.map);

--- a/src/lib/wildcam-darien.mapConfig.js
+++ b/src/lib/wildcam-darien.mapConfig.js
@@ -71,11 +71,68 @@ const mapConfig = {
     ],
     extraLayers: [
       {
-        'name': 'Vegetation Types',
-        'url': 'https://wildcam-darien.carto.com/api/v2/sql?q=SELECT%20*%20FROM%20vegetation_map',
-        'styles': {
+        'name': 'darien_national_park',
+        'label': 'Darien National Parks',
+        'query': 'SELECT * FROM darien_national_park',
+        'style': function (feature) {
+          return {
+            stroke: true,
+            color: '#3cc',
+            fill: false,
+          };
+        },
+      },
+      {
+        'name': 'soberania_national_park',
+        'label': 'Soberania National Parks',
+        'query': 'SELECT * FROM soberania_national_park',
+        'style': function (feature) {
+          return {
+            stroke: true,
+            color: '#3cc',
+            fill: false,
+          };
+        },
+      },
+      {
+        'name': 'veg_type',
+        'label': 'Habitats',
+        'query': 'SELECT * FROM vegetation_map',
+        'style': function (feature) {
+          console.log(feature);
+          let color = '#ccc';
+          if (feature && feature.properties) {
+            switch (feature.properties.veg_type) {
+              case 'Evergreen tropical ombrophilous broadleaf submontane (500 - 1,000 m Caribbean, 700 - 1,200 m Pacific)':
+                color = '#9c3'; break;
+              case 'Production system with significant natural or spontaneous woody vegetation (10 - 50%)':
+                color = '#993'; break;
+              case 'Production system with significant natural or spontaneous woody vegetation (<10%)':
+                color = '#693'; break;
+              case 'Evergreen ombrophylous tropical lowland broadleaf forest - heavily logged':
+                color = '#663'; break;
+              case 'Tropical lowland semi-deciduous forest - heavily logged':
+                color = '#393'; break;
+              case 'Water':
+                color = '#39c'; break;
+              case 'Tropical lowland semi-deciduous forest':
+                color = '#9c6'; break;
+              case 'Tropical lowland semi-deciduous forest - minimally logged':
+                color = '#6c6'; break;
+              case 'Evergreen tropical ombrophilous broadleaf montane montane (1,000 - 1,500 m Caribbean, 1,200 - 1,800 m Pacific)':
+                color = '#cc6'; break;
+              case 'Evergreen, broad-leaved tropical broad-leaved evergreen forest':
+                color = '#9c9'; break;
+            }
+          }
           
-        }
+          return {
+            stroke: false,
+            fill: true,
+            fillColor: color,
+            fillOpacity: 0.2,
+          };
+        },
       },
     ],
     'filters': {

--- a/src/lib/wildcam-darien.mapConfig.js
+++ b/src/lib/wildcam-darien.mapConfig.js
@@ -72,7 +72,7 @@ const mapConfig = {
     extraLayers: [
       {
         'name': 'darien_national_park',
-        'label': 'Darien National Parks',
+        'label': 'Darien National Park',
         'query': 'SELECT * FROM darien_national_park',
         'style': function (feature) {
           return {
@@ -84,7 +84,7 @@ const mapConfig = {
       },
       {
         'name': 'soberania_national_park',
-        'label': 'Soberania National Parks',
+        'label': 'Soberania National Park',
         'query': 'SELECT * FROM soberania_national_park',
         'style': function (feature) {
           return {
@@ -130,7 +130,7 @@ const mapConfig = {
             stroke: false,
             fill: true,
             fillColor: color,
-            fillOpacity: 0.2,
+            fillOpacity: 0.5,
           };
         },
       },

--- a/src/lib/wildcam-darien.mapConfig.js
+++ b/src/lib/wildcam-darien.mapConfig.js
@@ -99,7 +99,6 @@ const mapConfig = {
         'label': 'Habitats',
         'query': 'SELECT * FROM vegetation_map',
         'style': function (feature) {
-          console.log(feature);
           let color = '#ccc';
           if (feature && feature.properties) {
             switch (feature.properties.veg_type) {
@@ -135,6 +134,21 @@ const mapConfig = {
         },
       },
     ],
+    'legend': {
+      'type': 'simple',
+      'items': {
+        '#9c3': 'Evergreen tropical ombrophilous broadleaf submontane (500 - 1,000 m Caribbean, 700 - 1,200 m Pacific)',
+        '#993': 'Production system with significant natural or spontaneous woody vegetation (10 - 50%)',
+        '#693': 'Production system with significant natural or spontaneous woody vegetation (<10%)',
+        '#663': 'Evergreen ombrophylous tropical lowland broadleaf forest - heavily logged',
+        '#393': 'Tropical lowland semi-deciduous forest - heavily logged',
+        '#39c': 'Water',
+        '#9c6': 'Tropical lowland semi-deciduous forest',
+        '#6c6': 'Tropical lowland semi-deciduous forest - minimally logged',
+        '#cc6': 'Evergreen tropical ombrophilous broadleaf montane montane (1,000 - 1,500 m Caribbean, 1,200 - 1,800 m Pacific)',
+        '#9c9': 'Evergreen, broad-leaved tropical broad-leaved evergreen forest',
+      },
+    },
     'filters': {
       'data_choice': {
         'label': 'Species',

--- a/src/lib/wildcam-darien.mapConfig.js
+++ b/src/lib/wildcam-darien.mapConfig.js
@@ -112,7 +112,7 @@ const mapConfig = {
                 color = '#663'; break;
               case 'Tropical lowland semi-deciduous forest - heavily logged':
                 color = '#393'; break;
-              case 'Water':
+              case 'Water region':
                 color = '#39c'; break;
               case 'Tropical lowland semi-deciduous forest':
                 color = '#9c6'; break;
@@ -142,7 +142,7 @@ const mapConfig = {
         '#693': 'Production system with significant natural or spontaneous woody vegetation (<10%)',
         '#663': 'Evergreen ombrophylous tropical lowland broadleaf forest - heavily logged',
         '#393': 'Tropical lowland semi-deciduous forest - heavily logged',
-        '#39c': 'Water',
+        '#39c': 'Water region',
         '#9c6': 'Tropical lowland semi-deciduous forest',
         '#6c6': 'Tropical lowland semi-deciduous forest - minimally logged',
         '#cc6': 'Evergreen tropical ombrophilous broadleaf montane montane (1,000 - 1,500 m Caribbean, 1,200 - 1,800 m Pacific)',

--- a/src/lib/zooniversal-translator.es.js
+++ b/src/lib/zooniversal-translator.es.js
@@ -33,6 +33,10 @@ let SpanishTranslations = {
   'Tropical lowland semi-deciduous forest - minimally logged': 'Bosque semi-deciduo de tierras bajas tropicales',
   'Evergreen tropical ombrophilous broadleaf montane montane (1,000 - 1,500 m Caribbean, 1,200 - 1,800 m Pacific)': 'Montano montana de hoja ancha ombrófila tropical de hoja perenne (1,000 - 1,500 m Caribe, 1,200 - 1,800 m Pacífico)',
   'Evergreen, broad-leaved tropical broad-leaved evergreen forest': 'Evergreen, de hoja ancha de hoja ancha de hoja perenne de hoja perenne',
+  
+  'Cameras': 'Cámaras',
+  'Darien National Park': 'Parque Nacional Darien',
+  'Soberania National Park': 'Parque Nacional Soberania',
 
   //Database
   'cartodb_id': null,

--- a/src/lib/zooniversal-translator.es.js
+++ b/src/lib/zooniversal-translator.es.js
@@ -16,6 +16,23 @@ let SpanishTranslations = {
   
   //CameraViewerPaging
   'Page': 'Página',
+  
+  //Map Layers, etc
+  'Terrain': 'Terreno',
+  'Terrain (Shaded)': 'Terreno (Sombreado)',
+  'Roads': 'Carreteras',
+  'Satellite': 'Satélite',
+  'Plain': 'Llanura',
+  'Evergreen tropical ombrophilous broadleaf submontane (500 - 1,000 m Caribbean, 700 - 1,200 m Pacific)': 'Submontano de hoja ancha ombrófila tropical perenne (500 - 1,000 m Caribe, 700 - 1,200 m Pacífico)',
+  'Production system with significant natural or spontaneous woody vegetation (10 - 50%)': 'Sistema de producción con significativa vegetación leñosa natural o espontánea (10 - 50%)',
+  'Production system with significant natural or spontaneous woody vegetation (<10%)': 'Sistema de producción con significativa vegetación leñosa natural o espontánea (<10%)',
+  'Evergreen ombrophylous tropical lowland broadleaf forest - heavily logged': 'Bosque de hoja ancha tropical ombrófilo tropical de hoja perenne - densamente explotado',
+  'Tropical lowland semi-deciduous forest - heavily logged': 'Bosque semi-deciduo de tierras bajas tropicales - muy explotado',
+  'Water region': 'Región del agua',
+  'Tropical lowland semi-deciduous forest': 'Bosque semi-deciduo tropical de tierras bajas',
+  'Tropical lowland semi-deciduous forest - minimally logged': 'Bosque semi-deciduo de tierras bajas tropicales',
+  'Evergreen tropical ombrophilous broadleaf montane montane (1,000 - 1,500 m Caribbean, 1,200 - 1,800 m Pacific)': 'Montano montana de hoja ancha ombrófila tropical de hoja perenne (1,000 - 1,500 m Caribe, 1,200 - 1,800 m Pacífico)',
+  'Evergreen, broad-leaved tropical broad-leaved evergreen forest': 'Evergreen, de hoja ancha de hoja ancha de hoja perenne de hoja perenne',
 
   //Database
   'cartodb_id': null,

--- a/src/styles/components/map-explorer.styl
+++ b/src/styles/components/map-explorer.styl
@@ -66,6 +66,18 @@
     .grommetux-accordion .grommetux-accordion
       padding-left: 1em
   
+  .map-legend
+    background: #fff
+    font-size: 0.8em
+    max-height: 16em
+    max-width: 16em
+    overflow: auto
+    
+    .map-legend-item
+      svg
+        flex: 0 0 auto
+        margin: 0.2em
+  
 .camera-viewer
   z-index: 2000  //Required to place controls above .map-visuals's Leaflet map
   padding: 1em

--- a/src/styles/components/map-explorer.styl
+++ b/src/styles/components/map-explorer.styl
@@ -74,6 +74,8 @@
     overflow: auto
     
     .map-legend-item
+      padding: 0.2em
+      
       svg
         flex: 0 0 auto
         margin: 0.2em


### PR DESCRIPTION
## PR Overview
* This PR adds the 'region' layers to the map.
* Notably: the park boundaries for the two national parks, and the areas of vegetation.
![screen shot 2017-08-29 at 16 11 38](https://user-images.githubusercontent.com/13952701/29828508-cd0b0488-8cd4-11e7-9437-e0b47e9e7672.png)
* These layers can be controlled by the 'Layers' control on the top-left corner of the Map.

### Potential for Improvement
* This map has no legends. It could probably use some?
* The layer order is fairly random? So sometimes the Data (camera map markers) layer is below the park boundaries, which isn't what we want? 

### Status
Ready for review, but it'll make more sense to merge PR #39 and #40 first, then review & rebase this branch onto the new master.