### PR TITLE
Fix Education API URL for Staging

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -24,7 +24,7 @@ const baseConfig = {
   'development': {
     astroProjects: ['1315'],
     panoptesAppId: '397e9bf4e29e75c0a092261ebe3338d3ef2687f2c5935d55c7ca0f63ecc2dd33',
-    root: 'https://education.staging.zooniverse.org/'
+    root: 'https://education-api-staging.zooniverse.org/'
   },
   'production': {
     astroProjects: [],


### PR DESCRIPTION
## PR Overview
* Without this PR, when you go to http://localhost:3998 and log in as `zootester1`, you'll see _no_ Classrooms listed under the Intro2Astro section.
  * In the console, you'll notice several 502 errors indicating the necessary Classroom/EduAPI resources could not be reached.
* This PR fixes the issue by changing the URL for the Education API (Staging version) to the correct value.
* To confirm, go to http://localhost:3998, log in as `zootester1` (on the Panoptes _Staging_ login screen), and you'll see at least one pre-made Class and Assignment there. (Star Wars, FYI.)
  * You should see NO 502 Gateway errors in the console.

NOTE: This fix was also contingent on the Panoptes Staging doorkeeper system being set up properly. Should be irrelevant to this PR since the setup works perfectly, but worth noting in case we encounter similar problems in the future - there are two parts to the solution: the client issue and the doorkeeper setup.

### Status
Ready to merge
