### PR TITLE
Auto create assignments

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Actions } from 'jumpstate';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import Box from 'grommet/components/Box';
+import Table from 'grommet/components/Table';
+import TableRow from 'grommet/components/TableRow';
+import EditIcon from 'grommet/components/icons/base/Edit';
+import CloseIcon from 'grommet/components/icons/base/Close';
+import Anchor from 'grommet/components/Anchor';
+import Button from 'grommet/components/Button';
+import Paragraph from 'grommet/components/Paragraph';
+import Spinning from 'grommet/components/icons/Spinning';
+
+import {
+  ASSIGNMENTS_STATUS, ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
+} from '../../ducks/assignments';
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+
+const AstroClassroomsTable = (props) => {
+  return (
+    <Table className="manager-table">
+      <thead className="manager-table__headers">
+        <TableRow>
+          <th id="assignments" scope="col" className="manager-table__caption">Your Classrooms</th>
+          <th id="completed" scope="col" className="headers__header">Completed</th>
+          <th id="export" scope="col" className="headers__header">Export Data</th>
+          <th id="view-project" scope="col" className="headers__header">View Project</th>
+        </TableRow>
+      </thead>
+      {props.classrooms.map((classroom) => {
+        // TODO update URL once we have staging/production hosts
+
+        const joinURL = `${window.location.host}/#${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
+        // Can we get linked assignments with classrooms in single get request?
+        // No, if we want this, then we need to open an issue with the API
+        // TODO replace classifications_target with calculated percentage
+
+        // The trailing slash is inconsistent in React Router 4's match.url property...
+        const editURL = (props.match.url[props.match.url.length - 1] === '/') ? props.match.url : `${props.match.url}/`;
+        return (
+          <tbody className="manager-table__body" key={classroom.id}>
+            <TableRow>
+              <th className="manager-table__row-header" id="classroom" colSpan="4" scope="colgroup">
+                <Box pad="none" margin="none" justify="between" direction="row">
+                  <span>
+                    <Button
+                      className="manager-table__button--edit"
+                      path={`${editURL}classrooms/${classroom.id}`}
+                      onClick={() => { Actions.classrooms.selectClassroom(classroom); }}
+                      icon={<EditIcon size="small" />}
+                    />
+                    {' '}{classroom.name}{' '}
+                    <CopyToClipboard text={joinURL} onCopy={() => { Actions.classrooms.setToastState({ status: 'ok', message: 'Copied join link.' }); }}>
+                      <Button type="button" className="manager-table__button--as-link" plain={true} onClick={() => {}}>
+                        Copy Join Link
+                      </Button>
+                    </CopyToClipboard>
+                  </span>
+                  <Button className="manager-table__button--delete" type="button" onClick={props.maybeDeleteClassroom.bind(null, classroom.id)}>
+                    <CloseIcon size="small" />
+                  </Button>
+                </Box>
+              </th>
+            </TableRow>
+            {(props.assignments[classroom.id] &&
+              props.assignments[classroom.id].length === 0 &&
+              props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING) &&
+              <TableRow className="manager-table__row-data">
+                <td colSpan="4"><Spinning /></td>
+              </TableRow>}
+            {(props.assignments[classroom.id] &&
+              props.assignments[classroom.id].length === 0 &&
+              props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
+              <TableRow className="manager-table__row-data">
+                <td colSpan="4"><Paragraph>No assignments have been created yet.</Paragraph></td>
+              </TableRow>}
+            {(props.assignments[classroom.id] && props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
+              props.assignments[classroom.id].map((assignment) => {
+                return (
+                  <TableRow className="manager-table__row-data" key={assignment.id}>
+                    <td headers="classroom assignments">{assignment.name}</td>
+                    <td headers="classroom completed">
+                      {(assignment.metadata && assignment.metadata.classifications_target) ?
+                        assignment.metadata.classifications_target : ''}
+                    </td>
+                    <td headers="classroom export">
+                      <Button
+                        type="button"
+                        className="manager-table__button--as-link"
+                        plain={true}
+                        onClick={() => {}}
+                      >
+                        Export Data{' '}
+                        <i className="fa fa-arrow-down" aria-hidden="true"></i>
+                      </Button>
+                    </td>
+                    <td headers="classroom view-project">
+                      <Anchor
+                        className="manager-table__link"
+                        href="#"
+                      >
+                        Project Page{' '}
+                        <i className="fa fa-mail-forward" aria-hidden="true"></i>
+                      </Anchor>
+                    </td>
+                  </TableRow>
+                );
+              })}
+          </tbody>
+        );
+      })}
+    </Table>
+  );
+};
+
+AstroClassroomsTable.defaultProps = {
+  classroomInstructions: '',
+  closeConfirmationDialog: () => {},
+  deleteClassroom: () => {},
+  maybeDeleteClassroom: () => {},
+  selectClassroom: () => {},
+  ...CLASSROOMS_INITIAL_STATE,
+  ...ASSIGNMENTS_INITIAL_STATE
+};
+
+AstroClassroomsTable.propTypes = {
+  classroomInstructions: PropTypes.string,
+  closeConfirmationDialog: PropTypes.func,
+  deleteClassroom: PropTypes.func,
+  maybeDeleteClassroom: PropTypes.func,
+  selectClassroom: PropTypes.func,
+  ...CLASSROOMS_PROPTYPES,
+  ...ASSIGNMENTS_PROPTYPES
+};
+
+export default AstroClassroomsTable;

--- a/src/components/classrooms/ClassroomsManager.jsx
+++ b/src/components/classrooms/ClassroomsManager.jsx
@@ -6,23 +6,15 @@ import Box from 'grommet/components/Box';
 import Paragraph from 'grommet/components/Paragraph';
 import Button from 'grommet/components/Button';
 import Spinning from 'grommet/components/icons/Spinning';
-import Table from 'grommet/components/Table';
-import TableRow from 'grommet/components/TableRow';
-import Anchor from 'grommet/components/Anchor';
 import Layer from 'grommet/components/Layer';
-import EditIcon from 'grommet/components/icons/base/Edit';
-import CloseIcon from 'grommet/components/icons/base/Close';
-import CopyToClipboard from 'react-copy-to-clipboard';
 
 import {
   CLASSROOMS_STATUS, CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
-import {
-  ASSIGNMENTS_STATUS, ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
-} from '../../ducks/assignments';
 
 import ClassroomFormContainer from '../../containers/classrooms/ClassroomFormContainer';
 import ConfirmationDialog from '../common/ConfirmationDialog';
+import ClassroomsTableContainer from '../../containers/classrooms/ClassroomsTableContainer';
 
 const ClassroomsManager = (props) => {
   // TODO: Pagination for Classrooms
@@ -34,14 +26,6 @@ const ClassroomsManager = (props) => {
         <Paragraph align="start" size="small">{classroomInstructions}</Paragraph>
         <Button type="button" primary={true} label="Create New Classroom" onClick={props.toggleFormVisibility} />
       </Box>
-      <ConfirmationDialog
-        confirmationButtonLabel="Delete"
-        onConfirmation={props.deleteClassroom}
-        onClose={props.closeConfirmationDialog}
-        showConfirmationDialog={props.showConfirmationDialog}
-      >
-        <Paragraph size="small">Deleting a classroom will also delete the associated assignments.</Paragraph>
-      </ConfirmationDialog>
       {props.showForm &&
         <Layer closer={true} onClose={props.toggleFormVisibility}>
           <ClassroomFormContainer heading="Create Classroom" submitLabel="Create" />
@@ -53,98 +37,11 @@ const ClassroomsManager = (props) => {
       {props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.ERROR &&
         <Paragraph>Error: Classrooms could not be loaded.</Paragraph>}
       {(props.classrooms.length > 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) &&
-        <Table className="manager-table">
-          <thead className="manager-table__headers">
-            <TableRow>
-              <th id="assignments" scope="col" className="manager-table__caption">Your Classrooms</th>
-              <th id="completed" scope="col" className="headers__header">Completed</th>
-              <th id="export" scope="col" className="headers__header">Export Data</th>
-              <th id="view-project" scope="col" className="headers__header">View Project</th>
-            </TableRow>
-          </thead>
-          {props.classrooms.map((classroom) => {
-            // TODO update URL once we have staging/production hosts
-
-            const joinURL = `${window.location.host}/#${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
-            // Can we get linked assignments with classrooms in single get request?
-            // No, if we want this, then we need to open an issue with the API
-            // TODO replace classifications_target with calculated percentage
-
-            // The trailing slash is inconsistent in React Router 4's match.url property...
-            const editURL = (props.match.url[props.match.url.length - 1] === '/') ? props.match.url : `${props.match.url}/`;
-            return (
-              <tbody className="manager-table__body" key={classroom.id}>
-                <TableRow>
-                  <th className="manager-table__row-header" id="classroom" colSpan="4" scope="colgroup">
-                    <Box pad="none" margin="none" justify="between" direction="row">
-                      <span>
-                        <Button
-                          className="manager-table__button--edit"
-                          path={`${editURL}classrooms/${classroom.id}`}
-                          onClick={() => { Actions.classrooms.selectClassroom(classroom); }}
-                          icon={<EditIcon size="small" />}
-                        />
-                        {' '}{classroom.name}{' '}
-                        <CopyToClipboard text={joinURL} onCopy={() => { Actions.classrooms.setToastState({ status: 'ok', message: 'Copied join link.' }); }}>
-                          <Button type="button" className="manager-table__button--as-link" plain={true} onClick={() => {}}>
-                            Copy Join Link
-                          </Button>
-                        </CopyToClipboard>
-                      </span>
-                      <Button className="manager-table__button--delete" type="button" onClick={props.maybeDeleteClassroom.bind(null, classroom.id)}>
-                        <CloseIcon size="small" />
-                      </Button>
-                    </Box>
-                  </th>
-                </TableRow>
-                {(props.assignments[classroom.id] &&
-                  props.assignments[classroom.id].length === 0 &&
-                  props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING) &&
-                  <TableRow className="manager-table__row-data">
-                    <td colSpan="4"><Spinning /></td>
-                  </TableRow>}
-                {(props.assignments[classroom.id] &&
-                  props.assignments[classroom.id].length === 0 &&
-                  props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
-                  <TableRow className="manager-table__row-data">
-                    <td colSpan="4"><Paragraph>No assignments have been created yet.</Paragraph></td>
-                  </TableRow>}
-                {(props.assignments[classroom.id] && props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
-                  props.assignments[classroom.id].map((assignment) => {
-                    return (
-                      <TableRow className="manager-table__row-data" key={assignment.id}>
-                        <td headers="classroom assignments">{assignment.name}</td>
-                        <td headers="classroom completed">
-                          {(assignment.metadata && assignment.metadata.classifications_target) ?
-                            assignment.metadata.classifications_target : ''}
-                        </td>
-                        <td headers="classroom export">
-                          <Button
-                            type="button"
-                            className="manager-table__button--as-link"
-                            plain={true}
-                            onClick={() => {}}
-                          >
-                            Export Data{' '}
-                            <i className="fa fa-arrow-down" aria-hidden="true"></i>
-                          </Button>
-                        </td>
-                        <td headers="classroom view-project">
-                          <Anchor
-                            className="manager-table__link"
-                            href="#"
-                          >
-                            Project Page{' '}
-                            <i className="fa fa-mail-forward" aria-hidden="true"></i>
-                          </Anchor>
-                        </td>
-                      </TableRow>
-                    );
-                  })}
-              </tbody>
-            );
-          })}
-        </Table>}
+        <ClassroomsTableContainer
+          deleteClassroom={props.deleteClassroom}
+          maybeDeleteClassroom={props.maybeDeleteClassroom}
+          match={props.match}
+        />}
     </Box>
   );
 };
@@ -154,11 +51,9 @@ ClassroomsManager.defaultProps = {
   closeConfirmationDialog: () => {},
   deleteClassroom: () => {},
   maybeDeleteClassroom: () => {},
-  selectClassroom: () => {},
   showForm: false,
   toggleFormVisibility: Actions.classrooms.toggleFormVisibility,
-  ...CLASSROOMS_INITIAL_STATE,
-  ...ASSIGNMENTS_INITIAL_STATE
+  ...CLASSROOMS_INITIAL_STATE
 };
 
 ClassroomsManager.propTypes = {
@@ -166,11 +61,9 @@ ClassroomsManager.propTypes = {
   closeConfirmationDialog: PropTypes.func,
   deleteClassroom: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
-  selectClassroom: PropTypes.func,
   showForm: PropTypes.bool,
   toggleFormVisibility: PropTypes.func,
-  ...CLASSROOMS_PROPTYPES,
-  ...ASSIGNMENTS_PROPTYPES
+  ...CLASSROOMS_PROPTYPES
 };
 
 export default ClassroomsManager;

--- a/src/containers/classrooms/ClassroomsManagerContainer.jsx
+++ b/src/containers/classrooms/ClassroomsManagerContainer.jsx
@@ -6,9 +6,6 @@ import ClassroomsManager from '../../components/classrooms/ClassroomsManager';
 import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
-import {
-  ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
-} from '../../ducks/assignments';
 
 export class ClassroomsManagerContainer extends React.Component {
   constructor(props) {
@@ -30,10 +27,6 @@ export class ClassroomsManagerContainer extends React.Component {
 
   componentWillUnmount() {
     Actions.classrooms.setClassrooms(CLASSROOMS_INITIAL_STATE.classrooms);
-  }
-
-  selectClassroom(classroom) {
-    Actions.classrooms.selectClassroom(classroom);
   }
 
   maybeDeleteClassroom(id) {
@@ -59,8 +52,6 @@ export class ClassroomsManagerContainer extends React.Component {
   render() {
     return (
       <ClassroomsManager
-        assignments={this.props.assignments}
-        assignmentsStatus={this.props.assignmentsStatus}
         classrooms={this.props.classrooms}
         classroomInstructions={this.props.classroomInstructions}
         classroomsStatus={this.props.classroomsStatus}
@@ -69,8 +60,6 @@ export class ClassroomsManagerContainer extends React.Component {
         deleteClassroom={this.deleteClassroom}
         match={this.props.match}
         maybeDeleteClassroom={this.maybeDeleteClassroom}
-        selectClassroom={this.selectClassroom}
-        selectedProgram={this.props.selectedProgram}
         showConfirmationDialog={this.state.showConfirmationDialog}
         showForm={this.props.showForm}
       />
@@ -79,23 +68,18 @@ export class ClassroomsManagerContainer extends React.Component {
 }
 
 ClassroomsManagerContainer.propTypes = {
-  ...ASSIGNMENTS_PROPTYPES,
   ...CLASSROOMS_PROPTYPES
 };
 
 ClassroomsManagerContainer.defaultProps = {
-  ...ASSIGNMENTS_INITIAL_STATE,
   ...CLASSROOMS_INITIAL_STATE
 };
 
 const mapStateToProps = (state) => ({
-  assignments: state.assignments.assignments,
-  assignmentsStatus: state.assignments.status,
   classrooms: state.classrooms.classrooms,
   classroomsStatus: state.classrooms.status,
   programs: state.programs.programs,
   selectedClassroom: state.classrooms.selectedClassroom,
-  selectedProgram: state.programs.selectedProgram,
   showConfirmationDialog: state.classrooms.showConfirmationDialog,
   showForm: state.classrooms.showForm
 });

--- a/src/containers/classrooms/ClassroomsTableContainer.jsx
+++ b/src/containers/classrooms/ClassroomsTableContainer.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
+import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
+
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+import {
+  ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
+} from '../../ducks/assignments';
+
+class ClassroomsTableContainer extends React.Component {
+  selectClassroom(classroom) {
+    Actions.classrooms.selectClassroom(classroom);
+  }
+
+  render() {
+    if (this.props.selectedProgram && this.props.selectedProgram.slug === '/astro-101-with-galaxy-zoo') {
+      return (
+        <AstroClassroomsTable
+          assignments={this.props.assignments}
+          assignmentsStatus={this.props.assignmentsStatus}
+          classrooms={this.props.classrooms}
+          deleteClassroom={this.props.deleteClassroom}
+          match={this.props.match}
+          maybeDeleteClassroom={this.props.maybeDeleteClassroom}
+          selectClassroom={this.selectClassroom}
+          selectedProgram={this.props.selectedProgram}
+        />
+      );
+    }
+
+    // TODO return the darien style classroom table
+    return null;
+  }
+}
+
+ClassroomsTableContainer.defaultProps = {
+  ...ASSIGNMENTS_INITIAL_STATE,
+  ...CLASSROOMS_INITIAL_STATE,
+  selectClassroom: () => {}
+};
+
+ClassroomsTableContainer.propTypes = {
+  ...ASSIGNMENTS_PROPTYPES,
+  ...CLASSROOMS_PROPTYPES,
+  selectClassroom: PropTypes.func
+};
+
+function mapStateToProps(state) {
+  return {
+    assignments: state.assignments.assignments,
+    assignmentsStatus: state.assignments.status,
+    classrooms: state.classrooms.classrooms,
+    selectedProgram: state.programs.selectedProgram
+  };
+}
+
+export default connect(mapStateToProps)(ClassroomsTableContainer);

--- a/src/containers/common/ProgramHomeContainer.jsx
+++ b/src/containers/common/ProgramHomeContainer.jsx
@@ -6,6 +6,8 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 
 import AstroHome from '../../components/astro/AstroHome';
 import DarienRoutesContainer from '../darien/DarienRoutesContainer';
+import DarienHome from '../../components/darien/DarienHome';
+import DarienExplorer from '../../components/darien/DarienExplorer';
 
 import {
   PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
@@ -29,6 +31,7 @@ export class ProgramHomeContainer extends React.Component {
   render() {
     // How do I pass props down consistently? They only get initial props, not the updated ones.
     // Check RR v.4 docs
+    console.log('what is going on', this.props.match)
     return (
       <Switch>
         <Route path="/astro-101-with-galaxy-zoo/educators" component={AstroHome} />

--- a/src/containers/common/ProgramHomeContainer.jsx
+++ b/src/containers/common/ProgramHomeContainer.jsx
@@ -6,8 +6,6 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 
 import AstroHome from '../../components/astro/AstroHome';
 import DarienRoutesContainer from '../darien/DarienRoutesContainer';
-import DarienHome from '../../components/darien/DarienHome';
-import DarienExplorer from '../../components/darien/DarienExplorer';
 
 import {
   PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
@@ -31,7 +29,6 @@ export class ProgramHomeContainer extends React.Component {
   render() {
     // How do I pass props down consistently? They only get initial props, not the updated ones.
     // Check RR v.4 docs
-    console.log('what is going on', this.props.match)
     return (
       <Switch>
         <Route path="/astro-101-with-galaxy-zoo/educators" component={AstroHome} />

--- a/src/containers/layout/AppNotification.jsx
+++ b/src/containers/layout/AppNotification.jsx
@@ -11,7 +11,6 @@ export class AppNotification extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.notification && nextProps.notification.message) {
-      console.log('nextProps.notification', nextProps.notification)
       window.scrollTo(0, 0);
     }
   }

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -69,7 +69,7 @@ Effect('getAssignments', (classroomId) => {
 Effect('createAssignment', (data) => {
   Actions.classrooms.setStatus(ASSIGNMENTS_STATUS.CREATING);
 
-  return post('/assignments', { data: { attributes: data } })
+  return post('/assignments', data)
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/assignments/createAssignment): No response'; }
       if (response.ok &&

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -1,6 +1,6 @@
 import { State, Effect, Actions } from 'jumpstate';
 import PropTypes from 'prop-types';
-import { get } from '../lib/edu-api';
+import { get, post } from '../lib/edu-api';
 
 // Constants
 const ASSIGNMENTS_STATUS = {
@@ -23,6 +23,14 @@ const ASSIGNMENTS_PROPTYPES = {
   status: PropTypes.string
 };
 
+// Helper Functions
+function handleError(error) {
+  Actions.assignments.setStatus(ASSIGNMENTS_STATUS.ERROR);
+  Actions.assignments.setError(error);
+  Actions.notification.setNotification({ status: 'critical' , message: 'Something went wrong.' });
+  console.error(error);
+}
+
 // Synchonous actions
 const setStatus = (state, status) => {
   return { ...state, status };
@@ -43,20 +51,35 @@ Effect('getAssignments', (classroomId) => {
   return get('/assignments', [{ classroom_id: classroomId }])
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
-        if (response.ok &&
-            response.body && response.body.data) {
-          return response.body.data;
-        }
-        throw 'ERROR (ducks/classrooms/getClassrooms): Invalid response';
-      })
+      if (response.ok &&
+          response.body && response.body.data) {
+        return response.body.data;
+      }
+      throw 'ERROR (ducks/classrooms/getClassrooms): Invalid response';
+    })
     .then((data) => {
       const assignmentsForClassroom = { [classroomId]: data };
       Actions.assignments.setStatus(ASSIGNMENTS_STATUS.SUCCESS);
       Actions.assignments.setAssignments(assignmentsForClassroom);
     }).catch((error) => {
-      Actions.assignments.setStatus(ASSIGNMENTS_STATUS.ERROR);
-      Actions.assignments.setError(error);
-      console.error(error);
+      handleError(error);
+    });
+});
+
+Effect('createAssignment', (data) => {
+  Actions.classrooms.setStatus(ASSIGNMENTS_STATUS.CREATING);
+
+  return post('/assignments', { data: { attributes: data } })
+    .then((response) => {
+      if (!response) { throw 'ERROR (ducks/assignments/createAssignment): No response'; }
+      if (response.ok &&
+          response.body && response.body.data) {
+        return Actions.assignments.setStatus(ASSIGNMENTS_STATUS.SUCCESS);
+      }
+      throw 'ERROR (ducks/assignments/createAssignment): Invalid response';
+    })
+    .catch((error) => {
+      handleError(error);
     });
 });
 

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -155,7 +155,9 @@ Effect('createClassroom', (data) => {
       if (!response) { throw 'ERROR (ducks/classrooms/createClassroom): No response'; }
       if (response.ok &&
           response.body && response.body.data) {
-        return Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
+        Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
+        console.log(response.body.data)
+        return response.body.data;
       }
       throw 'ERROR (ducks/classrooms/createClassroom): Invalid response';
     })

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -156,7 +156,6 @@ Effect('createClassroom', (data) => {
       if (response.ok &&
           response.body && response.body.data) {
         Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
-        console.log(response.body.data)
         return response.body.data;
       }
       throw 'ERROR (ducks/classrooms/createClassroom): Invalid response';

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -75,7 +75,7 @@ const i2a = {
   }
 };
 
-const darian = {
+const darien = {
   staging: {
     id: '2',
     name: 'Wildcam Darien Lab',
@@ -103,7 +103,7 @@ const darian = {
 
 const programsArray = [
   i2a[env],
-  darian[env]
+  darien[env]
 ];
 
 // Constants

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -1,55 +1,109 @@
 import { State, Effect, Actions } from 'jumpstate';
 import PropTypes from 'prop-types';
 import { get, post, put, httpDelete } from '../lib/edu-api';
+import { env } from '../lib/config';
 
 // testing mocks
 const i2a = {
-  id: '1',
-  name: 'Astro 101 with Galaxy Zoo',
-  description: 'Classroom tools for teaching Astronomy.',
-  slug: '/astro-101-with-galaxy-zoo',
-  metadata: {
-    backgroundImage: 'astro-background.jpg',
-    cardImage: 'home-card-intro-to-astro.jpg',
-    redirectOnJoin: false,
-    assignments: {
-      // workflow_id: { assignmentMetadata }
-      // used to relate the assignment resource that has a workflow id property
-      // back to a project without having to request that from Panoptes
-      // to then build the URL to the project in the UI.
-      // These are just test projects on staging...
-      1315: {
-        assignment: "Hubble's Law",
-        slug: 'srallen086/intro2astro-hubble-testing'
-      },
-      1771: {
-        assignment: 'Galaxy Zoo 101',
-        slug: 'srallen086/galaxy-zoo-in-astronomy-101'
-      },
-      3038: {
-        assignment: 'Introduction',
-        slug: 'srallen086/introduction-to-platform'
+  staging: {
+    id: '1',
+    name: 'Astro 101 with Galaxy Zoo',
+    description: 'Classroom tools for teaching Astronomy',
+    slug: '/astro-101-with-galaxy-zoo',
+    metadata: {
+      autoCreateAssignments: true,
+      backgroundImage: 'astro-background.jpg',
+      cardImage: 'home-card-intro-to-astro.jpg',
+      redirectOnJoin: false,
+      assignments: {
+        // workflow_id: { assignmentMetadata }
+        // used to relate the assignment resource that has a workflow id property
+        // back to a project without having to request that from Panoptes
+        // to then build the URL to the project in the UI.
+        // These are just test projects on staging...
+        2218: {
+          name: "Hubble's Law",
+          classification_target: 10,
+          slug: 'srallen086/intro2astro-hubble-testing'
+        },
+        3037: {
+          name: 'Galaxy Zoo 101',
+          classification_target: 22,
+          slug: 'srallen086/galaxy-zoo-in-astronomy-101'
+        },
+        3038: {
+          name: 'Introduction',
+          classification_target: 1,
+          slug: 'srallen086/introduction-to-platform'
+        }
+      }
+    }
+  },
+  production: {
+    id: '1',
+    name: 'Astro 101 with Galaxy Zoo',
+    description: 'Classroom tools for teaching Astronomy',
+    slug: '/astro-101-with-galaxy-zoo',
+    metadata: {
+      autoCreateAssignments: true,
+      backgroundImage: 'astro-background.jpg',
+      cardImage: 'home-card-intro-to-astro.jpg',
+      redirectOnJoin: false,
+      assignments: {
+        // workflow_id: { assignmentMetadata }
+        // used to relate the assignment resource that has a workflow id property
+        // back to a project without having to request that from Panoptes
+        // to then build the URL to the project in the UI.
+        // TODO: replace the workflow ids here with the production ids
+        1315: {
+          name: "Hubble's Law",
+          classification_target: 10,
+          slug: 'srallen086/intro2astro-hubble-testing'
+        },
+        1771: {
+          name: 'Galaxy Zoo 101',
+          classification_target: 22,
+          slug: 'srallen086/galaxy-zoo-in-astronomy-101'
+        },
+        3038: {
+          name: 'Introduction',
+          classification_target: 1,
+          slug: 'srallen086/introduction-to-platform'
+        }
       }
     }
   }
 };
 
 const darian = {
-  id: '2',
-  name: 'Wildcam Darien Lab',
-  description: 'A map for exploring camera trap data from the WildCam Darien project.',
-  slug: '/wildcam-darien-lab',
-  metadata: {
-    backgroundImage: '',
-    cardImage: 'home-card-wildcam-darien.jpg',
-    redirectOnJoin: true,
+  staging: {
+    id: '2',
+    name: 'Wildcam Darien Lab',
+    description: 'A map for exploring camera trap data from the WildCam Darien project.',
+    slug: '/wildcam-darien-lab',
+    metadata: {
+      backgroundImage: '',
+      cardImage: 'home-card-wildcam-darien.jpg',
+      redirectOnJoin: true,
+    }
+  },
+  production: {
+    id: '2',
+    name: 'Wildcam Darien Lab',
+    description: 'A map for exploring camera trap data from the WildCam Darien project.',
+    slug: '/wildcam-darien-lab',
+    metadata: {
+      backgroundImage: '',
+      cardImage: 'home-card-wildcam-darien.jpg',
+      redirectOnJoin: true,
+    }
   }
 };
 
 
 const programsArray = [
-  i2a,
-  darian
+  i2a[env],
+  darian[env]
 ];
 
 // Constants


### PR DESCRIPTION
This is a WIP branch to eventually close #55. This adds the `createAssignment` Effect in the assignment duck as well as some code to auto-create assignments if the program (like I2A) needs to do that. Right now I have some mocks for programs, but we should create these on the staging server. I'm planning on storing a lot of information in the metadata object on the program to keep track of the data needed for the assignments that will be auto-created.

It also should be noted, I branched this off of the `programs` branch, so this will need a rebase as soon as #52 is merged.

I'm not sure if this works yet as there's been issues with the education-api-staging server again this past week that hopefully will be addressed next week (noted in the slack channel; likely issue on docker swarm?). I'm depending on the program resource to exist and we don't want to deploy that to production yet, so we have to use staging here for development. 