### PR TITLE
Add I2A content. Style clean up. Fix routing bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5344,7 +5344,8 @@
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.0.0",
@@ -5663,9 +5664,9 @@
       "dev": true
     },
     "grommet": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-1.7.0.tgz",
-      "integrity": "sha1-8v9rE0ucThU+JqH94AYIIxF6auQ=",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-1.8.2.tgz",
+      "integrity": "sha1-lYD9swuBMNUh0h7wXpBQEIzsrQM=",
       "requires": {
         "classnames": "2.2.5",
         "deep-assign": "2.0.0",
@@ -5680,16 +5681,66 @@
         "inuit-responsive-tools": "0.1.3",
         "inuit-shared": "0.1.5",
         "lodash.zip": "4.2.0",
-        "markdown-to-jsx": "5.3.3",
+        "markdown-to-jsx": "5.4.2",
         "moment": "2.18.1",
         "prop-types": "15.5.10",
-        "react": "15.6.1",
-        "react-desc": "1.1.0",
-        "react-dom": "15.6.1",
-        "react-intl": "2.3.0",
+        "react-desc": "1.4.1",
+        "react-intl": "2.4.0",
         "react-router": "4.2.0",
-        "react-transition-group": "1.2.0",
-        "superagent": "3.5.2"
+        "react-transition-group": "1.2.1",
+        "superagent": "3.6.3"
+      },
+      "dependencies": {
+        "cookiejar": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+          "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "superagent": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.6.3.tgz",
+          "integrity": "sha512-GjsfCFijfjqoz2tRiStSOoTdy7gNZOcK3ar4zONP9D8dXQWE+Qg7cbePHimRpapo06WUvoU3dmgi2e4q+sab5A==",
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.1.1",
+            "debug": "3.1.0",
+            "extend": "3.0.0",
+            "form-data": "2.3.1",
+            "formidable": "1.1.1",
+            "methods": "1.1.2",
+            "mime": "1.4.1",
+            "qs": "6.5.1",
+            "readable-stream": "2.3.3"
+          }
+        }
       }
     },
     "growl": {
@@ -5973,6 +6024,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
       "requires": {
         "function-bind": "1.1.0"
       }
@@ -6674,9 +6726,9 @@
       "integrity": "sha1-tITO/Lk1PzdPJd44mjzuoa8Y18k="
     },
     "intl-messageformat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-1.3.0.tgz",
-      "integrity": "sha1-99kmre16OrGbLcYB79VOmaS9Tq4=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.1.0.tgz",
+      "integrity": "sha1-HFHadvAqP3s2BlTNxRu8TT+mxyw=",
       "requires": {
         "intl-messageformat-parser": "1.2.0"
       }
@@ -6687,11 +6739,11 @@
       "integrity": "sha1-WQa3+VOrdHDg3IVJCXtki5kYkv8="
     },
     "intl-relativeformat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-1.3.0.tgz",
-      "integrity": "sha1-iT3HB2/M04DPCRojAMOA+les5Fs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.0.0.tgz",
+      "integrity": "sha1-1rqdxsYlgZvAq9sdTiOBOLdIjyY=",
       "requires": {
-        "intl-messageformat": "1.3.0"
+        "intl-messageformat": "2.1.0"
       }
     },
     "inuit-defaults": {
@@ -6791,17 +6843,17 @@
       "dev": true
     },
     "is-alphabetical": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.0.tgz",
-      "integrity": "sha1-4lRMEwWCVfIUTLdXBmzTNCocjEY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
+      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
     },
     "is-alphanumerical": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.0.tgz",
-      "integrity": "sha1-4GSS5xnBvxXewjnk8a9fZ7TW578=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
+      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
       "requires": {
-        "is-alphabetical": "1.0.0",
-        "is-decimal": "1.0.0"
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
       }
     },
     "is-arrayish": {
@@ -6852,9 +6904,9 @@
       "dev": true
     },
     "is-decimal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.0.tgz",
-      "integrity": "sha1-lAV5tupjxigICmnmK9qIyEcLT+A="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
+      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -6923,9 +6975,9 @@
       "dev": true
     },
     "is-hexadecimal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.0.tgz",
-      "integrity": "sha1-XEWXcdKvmi45Ungf1U/LG8/kETw="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
+      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
     },
     "is-jpg": {
       "version": "1.0.0",
@@ -7111,9 +7163,9 @@
       "dev": true
     },
     "is-whitespace-character": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.0.tgz",
-      "integrity": "sha1-u/SoN2Tq0NRRvsKlUhjpGWGtwnU="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.1.tgz",
+      "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs="
     },
     "is-windows": {
       "version": "0.2.0",
@@ -7122,9 +7174,9 @@
       "dev": true
     },
     "is-word-character": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.0.tgz",
-      "integrity": "sha1-o6nl3a1wxcLuNvSpz8mlP0RTUkc="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz",
+      "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs="
     },
     "is-zip": {
       "version": "1.0.0",
@@ -7973,13 +8025,13 @@
       "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg="
     },
     "markdown-to-jsx": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-5.3.3.tgz",
-      "integrity": "sha1-PkhUjhXaBCbwGeuV+pbzOXuV4BI=",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-5.4.2.tgz",
+      "integrity": "sha1-LLOxzigAkZD2GezIxcixcUM/tWo=",
       "requires": {
         "lodash.get": "4.4.2",
         "prop-types": "15.5.10",
-        "remark-parse": "3.0.1",
+        "remark-parse": "4.0.0",
         "unified": "6.1.5"
       }
     },
@@ -9087,9 +9139,9 @@
         "character-entities": "1.2.1",
         "character-entities-legacy": "1.1.1",
         "character-reference-invalid": "1.1.1",
-        "is-alphanumerical": "1.0.0",
-        "is-decimal": "1.0.0",
-        "is-hexadecimal": "1.0.0"
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
       }
     },
     "parse-glob": {
@@ -10194,13 +10246,9 @@
       "dev": true
     },
     "react-desc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-1.1.0.tgz",
-      "integrity": "sha1-2eZa5SQB9Ui+acPWZE4UJawR3AQ=",
-      "requires": {
-        "prop-types": "15.5.10",
-        "react": "15.6.1"
-      }
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-1.4.1.tgz",
+      "integrity": "sha1-mb7d974ldZAtFZ6RlAjRGII8x4s="
     },
     "react-dom": {
       "version": "15.6.1",
@@ -10248,13 +10296,13 @@
       }
     },
     "react-intl": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.3.0.tgz",
-      "integrity": "sha1-4d9q9WZ/3wHL5KqyDhNyUeKuUUI=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.4.0.tgz",
+      "integrity": "sha1-ZsFNyd+ac7L7v71gIXJugKYT6xU=",
       "requires": {
         "intl-format-cache": "2.0.5",
-        "intl-messageformat": "1.3.0",
-        "intl-relativeformat": "1.3.0",
+        "intl-messageformat": "2.1.0",
+        "intl-relativeformat": "2.0.0",
         "invariant": "2.2.2"
       }
     },
@@ -10360,9 +10408,9 @@
       }
     },
     "react-transition-group": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.0.tgz",
-      "integrity": "sha1-tR/JIbDDg1p+98Vxx5/ILHPpIE8=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
       "requires": {
         "chain-function": "1.0.0",
         "dom-helpers": "3.2.1",
@@ -10709,16 +10757,15 @@
       "dev": true
     },
     "remark-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
-      "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
+      "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
       "requires": {
         "collapse-white-space": "1.0.3",
-        "has": "1.0.1",
-        "is-alphabetical": "1.0.0",
-        "is-decimal": "1.0.0",
-        "is-whitespace-character": "1.0.0",
-        "is-word-character": "1.0.0",
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "is-word-character": "1.0.1",
         "markdown-escapes": "1.0.1",
         "parse-entities": "1.1.1",
         "repeat-string": "1.6.1",
@@ -10727,7 +10774,7 @@
         "trim-trailing-lines": "1.1.0",
         "unherit": "1.1.0",
         "unist-util-remove-position": "1.1.1",
-        "vfile-location": "2.0.1",
+        "vfile-location": "2.0.2",
         "xtend": "4.0.1"
       }
     },
@@ -12560,7 +12607,7 @@
         "extend": "3.0.0",
         "is-plain-obj": "1.1.0",
         "trough": "1.0.1",
-        "vfile": "2.1.0",
+        "vfile": "2.2.0",
         "x-is-function": "1.0.4",
         "x-is-string": "0.1.0"
       }
@@ -12799,9 +12846,9 @@
       }
     },
     "vfile": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.1.0.tgz",
-      "integrity": "sha1-086Lgl57jVO4lhZDQSczgZNvAr0=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.2.0.tgz",
+      "integrity": "sha1-zkek+zNZIrIz5TXbD32BIdj87U4=",
       "requires": {
         "is-buffer": "1.1.5",
         "replace-ext": "1.0.0",
@@ -12809,9 +12856,9 @@
       }
     },
     "vfile-location": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.1.tgz",
-      "integrity": "sha1-C/iBb3MrD4vZAqVv2kxiyOk13FI="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.2.tgz",
+      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU="
     },
     "vinyl": {
       "version": "1.2.0",
@@ -13610,7 +13657,7 @@
       "resolved": "https://registry.npmjs.org/zoo-grommet/-/zoo-grommet-0.2.2.tgz",
       "integrity": "sha512-oYsW4egTaYLJjjFBBj990ZBTzei5J4lgLSteB1/yRWa83yWkiSrdYM96lbpHGxmyGHdeoaM0SVtEhI9EJtDX3Q==",
       "requires": {
-        "grommet": "1.7.0"
+        "grommet": "1.8.2"
       }
     },
     "zooniverse-react-components": {
@@ -13644,15 +13691,15 @@
             "inuit-responsive-tools": "0.1.3",
             "inuit-shared": "0.1.5",
             "lodash.zip": "4.2.0",
-            "markdown-to-jsx": "5.3.3",
+            "markdown-to-jsx": "5.4.2",
             "moment": "2.18.1",
             "prop-types": "15.5.10",
             "react": "15.6.1",
-            "react-desc": "1.1.0",
+            "react-desc": "1.4.1",
             "react-dom": "15.6.1",
-            "react-intl": "2.3.0",
+            "react-intl": "2.4.0",
             "react-router": "4.2.0",
-            "react-transition-group": "1.2.0",
+            "react-transition-group": "1.2.1",
             "superagent": "3.5.2"
           }
         }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   "homepage": "https://github.com/zooniverse/edu-api-front-end",
   "dependencies": {
     "browser-filesaver": "1.1.1",
+    "classnames": "~2.2.5",
     "debounce": "~1.0.2",
-    "grommet": "~1.7.0",
+    "grommet": "~1.8.2",
     "jumpstate": "^2.2.2",
     "leaflet": "1.2.0",
     "panoptes-client": "~2.7.2",

--- a/src/components/astro/AstroHome.jsx
+++ b/src/components/astro/AstroHome.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import { ZooniverseLogotype } from 'zooniverse-react-components';
-import Article from 'grommet/components/Article';
 import Section from 'grommet/components/Section';
 import Box from 'grommet/components/Box';
 import Hero from 'grommet/components/Hero';
@@ -11,7 +10,6 @@ import Image from 'grommet/components/Image';
 import Heading from 'grommet/components/Heading';
 import Button from 'grommet/components/Button';
 import Paragraph from 'grommet/components/Paragraph';
-import Anchor from 'grommet/components/Anchor';
 
 import ProgramHome from '../common/ProgramHome';
 import NeedHelp from '../common/NeedHelp';
@@ -30,12 +28,12 @@ const AstroHome = (props) => {
       null;
 
   const name = (selectedProgramExists && props.selectedProgram.name) ? props.selectedProgram.name : '';
-  const description = (selectedProgramExists && props.selectedProgram.description) ? props.selectedProgram.description : '';
+  const classroomInstructions = 'Before your term begins, students will set up a Zooniverse account and you will create a classroom to share the classroom\'s unique URLs for students to join and to keep track of their progress as they work through each assignment. It is recommended to remind students that they must be logged in to their Zooniverse accounts to be able to use the link.';
 
   return (
-    <ProgramHome>
+    <ProgramHome className="astro-home">
       <Hero
-        className="home__hero"
+        className="program-home__hero"
         background={backgroundImage}
         backgroundColorIndex="dark"
         size={signedIn ? 'medium' : 'large'}
@@ -45,11 +43,11 @@ const AstroHome = (props) => {
           <Section align="center">
             <Box align="center" direction={signedIn ? 'row' : 'column'} size="xxlarge">
               <span className="hero__big-circle"><span className="hero__small-circle" /></span>
-              <Heading align="center" tag="h1" className="home__header">{name}</Heading>
+              <Heading align="center" tag="h1" className="program-home__header">{name}</Heading>
             </Box>
             <Box align={signedIn ? 'start' : 'center'} textAlign={signedIn ? 'left' : 'center'} size="xlarge">
-              <Paragraph className="home__description" margin="small">
-                {description}
+              <Paragraph className="program-home__description" margin="small">
+                Tools and curricula for introductory astronomy students to learn common astronomy concepts as well as view, analyze, manipulate and visualize Galaxy Zoo data.
               </Paragraph>
             </Box>
           </Section>
@@ -61,7 +59,7 @@ const AstroHome = (props) => {
       </Hero>
       {signedIn &&
         <Section
-          className="home__section"
+          className="program-home__section"
           align="center"
           colorIndex="accent-3"
           direction="column"
@@ -69,15 +67,15 @@ const AstroHome = (props) => {
           pad={{ vertical: 'none', horizontal: 'none' }}
           justify="center"
         >
-          <Box align="center" direction="row" justify="center">
-            <Button href="#" type="button" label="Google Drive" />
+          <Box className="astro-home__guide" align="center" direction="row" size="xxlarge">
+            <Button href="https://drive.google.com/open?id=0Bww9uOqqZbR_aEhCYkRoRU1GUXc" type="button" label="Instructors Guide" target="_blank" rel="noopener noreferrer" />
             <Paragraph align="start">
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+                Instructors Guide: This provides you with a suggested timeline, lesson plans and student instructions for the class activities that will  guide the students in how to use the tools and the research project where students demonstrate the skills they have learned.
             </Paragraph>
           </Box>
-          <ClassroomsLayout match={props.match} />
+          <ClassroomsLayout match={props.match} classroomInstructions={classroomInstructions} />
         </Section>}
-        <NeedHelp />
+      <NeedHelp />
     </ProgramHome>
   );
 };
@@ -85,13 +83,13 @@ const AstroHome = (props) => {
 AstroHome.propTypes = {
   ...PROGRAMS_PROPTYPES,
   initialised: PropTypes.bool,
-  user: PropTypes.shape({ login: PropTypes.string }),
+  user: PropTypes.shape({ login: PropTypes.string })
 };
 
 AstroHome.defaultProps = {
   ...PROGRAMS_INITIAL_STATE,
   initialised: false,
-  user: null,
+  user: null
 };
 
 function mapStateToProps(state) {

--- a/src/components/classrooms/ClassroomsLayout.jsx
+++ b/src/components/classrooms/ClassroomsLayout.jsx
@@ -12,7 +12,7 @@ import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
 
-const ClassroomsLayout = ({ match, toast }) => {
+const ClassroomsLayout = ({ classroomInstructions, match, toast }) => {
   return (
     <Box
       className="classrooms-layout"
@@ -29,7 +29,7 @@ const ClassroomsLayout = ({ match, toast }) => {
           {toast.message}
         </Toast>}
       <Switch>
-        <Route exact path={`${match.url}`} component={ClassroomsManagerContainer} />
+        <Route exact path={`${match.url}`} component={ClassroomsManagerContainer} classroomInstructions={classroomInstructions} />
         <Route path={`${match.url}/classrooms/:id`} component={ClassroomEditorContainer} />
         <Redirect from={`${match.url}/classrooms`} to={`${match.url}`} />
       </Switch>

--- a/src/components/classrooms/ClassroomsManager.jsx
+++ b/src/components/classrooms/ClassroomsManager.jsx
@@ -18,12 +18,10 @@ import ClassroomsTableContainer from '../../containers/classrooms/ClassroomsTabl
 
 const ClassroomsManager = (props) => {
   // TODO: Pagination for Classrooms
-  const classroomInstructions = 'First, make sure your students have set up a Zooniverse account. Then create a classroom and share the classroom\'s unique join URL with your students to keep track of their progress as they work through each assignment. Students must be logged in to their Zooniverse accounts first to be able to use the join link. Share the URL under View Project with your students for them to complete the assignment.';
-
   return (
     <Box className="classrooms-manager">
-      <Box align="center" direction="row" justify="between">
-        <Paragraph align="start" size="small">{classroomInstructions}</Paragraph>
+      <Box className="classrooms-manager__instructions" align="center" direction="row" justify="between" size="xxlarge">
+        <Paragraph align="start" size="small">{props.classroomInstructions}</Paragraph>
         <Button type="button" primary={true} label="Create New Classroom" onClick={props.toggleFormVisibility} />
       </Box>
       {props.showForm &&
@@ -47,7 +45,7 @@ const ClassroomsManager = (props) => {
 };
 
 ClassroomsManager.defaultProps = {
-  classroomInstructions: '',
+  classroomInstructions: 'First, make sure your students have set up a Zooniverse account. Then create a classroom and share the classroom\'s unique join URL with your students to keep track of their progress as they work through each assignment. Students must be logged in to their Zooniverse accounts first to be able to use the join link. Share the URL under View Project with your students for them to complete the assignment.',
   closeConfirmationDialog: () => {},
   deleteClassroom: () => {},
   maybeDeleteClassroom: () => {},

--- a/src/components/common/ProgramHome.jsx
+++ b/src/components/common/ProgramHome.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import classnames from 'classnames';
 import Article from 'grommet/components/Article';
 
 export default function ProgramHome(props) {
+  const programHomeClassnames = classnames(
+    'program-home',
+    { [props.className]: props.className }
+  );
+
   return (
-    <Article className="home" colorIndex="accent-3">
+    <Article className={programHomeClassnames} colorIndex="accent-3">
       {props.children}
     </Article>
   );

--- a/src/components/darien/DarienHome.jsx
+++ b/src/components/darien/DarienHome.jsx
@@ -27,17 +27,17 @@ class DarienHome extends React.Component {
     const name = (selectedProgramExists && this.props.selectedProgram.name) ? this.props.selectedProgram.name : '';
 
     return (
-      <ProgramHome>
+      <ProgramHome className="darien-home">
         <Hero
-          className="home__hero"
+          className="program-home__hero"
           background={<Image src="https://placeimg.com/1000/1000/nature/any" fit="cover" />}
           backgroundColorIndex="dark"
           size="medium"
         >
-          <Box align="center"><Heading className="home__header">{name}</Heading></Box>
+          <Box align="center"><Heading className="program-home__header">{name}</Heading></Box>
         </Hero>
         <Section
-          className="home__section"
+          className="program-home__section"
           align="center"
           colorIndex="accent-3"
           direction="column"

--- a/src/containers/common/ProgramHomeContainer.jsx
+++ b/src/containers/common/ProgramHomeContainer.jsx
@@ -23,8 +23,14 @@ export class ProgramHomeContainer extends React.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.selectedProgram && nextProps.selectedProgram.slug !== nextProps.match.url) {
+      Actions.getProgram({ programs: this.props.programs, param: this.props.match.params.program });
+    }
+  }
+
   componentWillUnmount() {
-    Actions.programs.selectProgram(PROGRAMS_INITIAL_STATE.program);
+    Actions.programs.selectProgram(PROGRAMS_INITIAL_STATE.selectedProgram);
   }
 
   render() {

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -10,7 +10,7 @@ const i2a = {
   staging: {
     id: '1',
     name: 'Astro 101 with Galaxy Zoo',
-    description: 'Classroom tools for teaching Astronomy',
+    description: 'Materials and tools for engaging introductory astronomy students in real research with Galaxy Zoo.',
     slug: '/astro-101-with-galaxy-zoo',
     metadata: {
       autoCreateAssignments: true,
@@ -44,7 +44,7 @@ const i2a = {
   production: {
     id: '1',
     name: 'Astro 101 with Galaxy Zoo',
-    description: 'Classroom tools for teaching Astronomy',
+    description: 'Materials and tools for engaging introductory astronomy students in real research with Galaxy Zoo.',
     slug: '/astro-101-with-galaxy-zoo',
     metadata: {
       autoCreateAssignments: true,

--- a/src/styles/components/astro-home.styl
+++ b/src/styles/components/astro-home.styl
@@ -1,0 +1,4 @@
+.astro-home
+  &__guide
+    // Applying style manually because justify="between" seems broken in Grommet v1.8.2
+    justify-content: space-between

--- a/src/styles/components/classrooms-manager.styl
+++ b/src/styles/components/classrooms-manager.styl
@@ -1,4 +1,7 @@
 .classrooms-manager
+  &__instructions
+    margin: 0 auto
+
   .manager-table
     background-color: white
     border: solid 2px #DEDEDE

--- a/src/styles/components/program-home.styl
+++ b/src/styles/components/program-home.styl
@@ -1,4 +1,4 @@
-.home
+.program-home
   &__hero
     .grommetux-hero__foreground
       svg // fix the zooniverse-logotype to apply className props.


### PR DESCRIPTION
This PR does a few things:
- Updates `grommet` to 1.8.2 and adds `classnames`
- I replaced some placeholder text with the actual text that will be used for I2A
- Reworked the classes used by `ProgramHome` and added styles specific to `AstroHome`
- Added the URL for the I2A Instructor's Guide
- Fixed a routing bug with the header links between the I2A and Wildcam Darien Lab using 