### PR TITLE
Fix regression with ConfirmationDialog on classroom delete

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -131,7 +131,6 @@ const AstroClassroomsTable = (props) => {
 AstroClassroomsTable.defaultProps = {
   classroomInstructions: '',
   closeConfirmationDialog: () => {},
-  deleteClassroom: () => {},
   maybeDeleteClassroom: () => {},
   selectClassroom: () => {},
   ...CLASSROOMS_INITIAL_STATE,
@@ -141,7 +140,6 @@ AstroClassroomsTable.defaultProps = {
 AstroClassroomsTable.propTypes = {
   classroomInstructions: PropTypes.string,
   closeConfirmationDialog: PropTypes.func,
-  deleteClassroom: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
   selectClassroom: PropTypes.func,
   ...CLASSROOMS_PROPTYPES,

--- a/src/components/classrooms/ClassroomsManager.jsx
+++ b/src/components/classrooms/ClassroomsManager.jsx
@@ -24,6 +24,14 @@ const ClassroomsManager = (props) => {
         <Paragraph align="start" size="small">{props.classroomInstructions}</Paragraph>
         <Button type="button" primary={true} label="Create New Classroom" onClick={props.toggleFormVisibility} />
       </Box>
+      <ConfirmationDialog
+        confirmationButtonLabel="Delete"
+        onConfirmation={props.deleteClassroom}
+        onClose={props.closeConfirmationDialog}
+        showConfirmationDialog={props.showConfirmationDialog}
+      >
+        <Paragraph size="small">Deleting a classroom will also delete the associated assignments.</Paragraph>
+      </ConfirmationDialog>
       {props.showForm &&
         <Layer closer={true} onClose={props.toggleFormVisibility}>
           <ClassroomFormContainer heading="Create Classroom" submitLabel="Create" />
@@ -36,7 +44,6 @@ const ClassroomsManager = (props) => {
         <Paragraph>Error: Classrooms could not be loaded.</Paragraph>}
       {(props.classrooms.length > 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) &&
         <ClassroomsTableContainer
-          deleteClassroom={props.deleteClassroom}
           maybeDeleteClassroom={props.maybeDeleteClassroom}
           match={props.match}
         />}

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -94,10 +94,13 @@ export class ClassroomEditorContainer extends React.Component {
   removeStudentFromClassroom() {
     if (this.state.studentToDelete === null) return;
 
-    Actions.removeStudentFromClassroom(this.state.studentToDelete).then(() => {
+    Actions.removeStudentFromClassroom(this.state.studentToDelete).then((response) => {
       Actions.getClassroom(this.props.match.params.id);
       this.closeConfirmationDialog();
-      Actions.classrooms.setToastState({ status: 'ok', message: 'Student removed' });
+
+      if (response) {
+        Actions.classrooms.setToastState({ status: 'ok', message: 'Student removed' });
+      }
     });
   }
 

--- a/src/containers/classrooms/ClassroomsManagerContainer.jsx
+++ b/src/containers/classrooms/ClassroomsManagerContainer.jsx
@@ -40,12 +40,15 @@ export class ClassroomsManagerContainer extends React.Component {
   deleteClassroom() {
     if (this.state.classroomToDelete === null) return;
 
-    Actions.deleteClassroom(this.state.classroomToDelete).then(() => {
+    Actions.deleteClassroom(this.state.classroomToDelete).then((response) => {
       // TODO: For API optimization, do we want to instead manually remove the classroom
       // out of local app state instead of making another API call
       Actions.getClassroomsAndAssignments();
       this.closeConfirmationDialog();
-      Actions.classrooms.setToastState({ status: 'ok', message: 'Classroom deleted' });
+
+      if (response) {
+        Actions.classrooms.setToastState({ status: 'ok', message: 'Classroom deleted' });
+      }
     });
   }
 

--- a/src/containers/classrooms/ClassroomsTableContainer.jsx
+++ b/src/containers/classrooms/ClassroomsTableContainer.jsx
@@ -24,7 +24,6 @@ class ClassroomsTableContainer extends React.Component {
           assignments={this.props.assignments}
           assignmentsStatus={this.props.assignmentsStatus}
           classrooms={this.props.classrooms}
-          deleteClassroom={this.props.deleteClassroom}
           match={this.props.match}
           maybeDeleteClassroom={this.props.maybeDeleteClassroom}
           selectClassroom={this.selectClassroom}


### PR DESCRIPTION
I think this was a regression that came in with #56. In the reorganization I did, I think I accidentally removed the `ConfirmationDialog` used with the classroom delete button.

I did some minor improvements with the success handling of the delete requests for both classroom and student. We only want to show the success message if there's a response from the API. 