### PR TITLE
Request programs

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -40,7 +40,7 @@ const AstroClassroomsTable = (props) => {
         {props.classrooms.map((classroom) => {
           // TODO update URL once we have staging/production hosts
 
-          const joinURL = `${window.location.host}/#${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
+          const joinURL = `${window.location.host}/#/${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
           // Can we get linked assignments with classrooms in single get request?
           // No, if we want this, then we need to open an issue with the API
           // TODO replace classifications_target with calculated percentage

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -31,7 +31,7 @@ import {
 
 const ClassroomEditor = (props) => {
   const joinURL = props.selectedClassroom ?
-    `${window.location.host}/#${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}` :
+    `${window.location.host}/#/${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}` :
     '';
 
   // Get students and assignments only for this classroom.

--- a/src/components/common/GenericStatusPage.jsx
+++ b/src/components/common/GenericStatusPage.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Section from 'grommet/components/Section';
+import Paragraph from 'grommet/components/Paragraph';
+import Spinning from 'grommet/components/icons/Spinning';
+import Status from 'grommet/components/icons/Status';
+
+const GenericStatusPage = (props) => {
+  const statusComponent = props.status === 'fetching' ? <Spinning /> : <Status value={props.status} />
+  return (
+    <Section align="center" colorIndex="light-2" full={true} justify="center" direction="row">
+      {statusComponent}{' '}
+      {props.message &&
+        <Paragraph>{props.message}</Paragraph>}
+    </Section>
+  );
+}
+
+GenericStatusPage.defaultProps = {
+  message: '',
+  status: 'ok'
+};
+
+GenericStatusPage.propTypes = {
+  message: PropTypes.string,
+  status: PropTypes.string
+}
+
+export default GenericStatusPage;

--- a/src/containers/common/HomeContainer.jsx
+++ b/src/containers/common/HomeContainer.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
 import Home from '../../components/common/Home';
+import { post } from '../../lib/edu-api';
 
 class HomeContainer extends React.Component {
   constructor(props) {
@@ -11,7 +12,7 @@ class HomeContainer extends React.Component {
   }
 
   componentDidMount() {
-    // Actions.getPrograms();
+    Actions.getPrograms();
   }
 
   render() {

--- a/src/containers/common/ProgramHomeContainer.jsx
+++ b/src/containers/common/ProgramHomeContainer.jsx
@@ -7,25 +7,34 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 import JoinPageContainer from './JoinPageContainer';
 import AstroHome from '../../components/astro/AstroHome';
 import DarienRoutesContainer from '../darien/DarienRoutesContainer';
+import GenericStatusPage from '../../components/common/GenericStatusPage';
 
 import {
-  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
+  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES, PROGRAMS_STATUS
 } from '../../ducks/programs';
 
 export class ProgramHomeContainer extends React.Component {
   constructor() {
     super();
+
+    this.getProgram = this.getProgram.bind(this);
   }
 
   componentDidMount() {
-    if (!this.props.selectedProgram) {
-      Actions.getProgram({ programs: this.props.programs, param: this.props.match.params.program });
+    if (this.props.programs.length === 0 && !this.props.selectedProgram) {
+      Actions.getPrograms().then((programs) => {
+        this.getProgram(programs, this.props.match.params.program)
+      });
+    }
+
+    if (this.props.programs && !this.props.selectedProgram) {
+      this.getProgram(this.props.programs, this.props.match.params.program);
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.selectedProgram && nextProps.selectedProgram.slug !== nextProps.match.url) {
-      Actions.getProgram({ programs: this.props.programs, param: this.props.match.params.program });
+    if (nextProps.programs.length > 0 && nextProps.selectedProgram && nextProps.selectedProgram.slug !== nextProps.match.params.program) {
+      this.getProgram(nextProps.programs, nextProps.match.params.program);
     }
   }
 
@@ -33,9 +42,22 @@ export class ProgramHomeContainer extends React.Component {
     Actions.programs.selectProgram(PROGRAMS_INITIAL_STATE.selectedProgram);
   }
 
+  getProgram(programs, param) {
+    Actions.getProgram({ programs, param });
+  }
+
   render() {
     // How do I pass props down consistently? They only get initial props, not the updated ones.
     // Check RR v.4 docs
+
+    if (this.props.programsStatus === PROGRAMS_STATUS.FETCHING) {
+      return (<GenericStatusPage status={this.props.programsStatus} message="Loading" />)
+    }
+
+    if (this.props.programsStatus === PROGRAMS_STATUS.ERROR) {
+      return (<GenericStatusPage status="critical" message="Something went wrong" />)
+    }
+
     return (
       <Switch>
         <Route path="/:program/students/classrooms/:classroomId/join" component={JoinPageContainer} />
@@ -62,6 +84,7 @@ ProgramHomeContainer.defaultProps = {
 function mapStateToProps(state) {
   return {
     initialised: state.auth.initialised,
+    programs: state.programs.programs,
     programsStatus: state.programs.status,
     selectedProgram: state.programs.selectedProgram,
     user: state.auth.user

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -176,19 +176,17 @@ const setError = (state, error) => {
 Effect('getPrograms', () => {
   Actions.programs.setStatus(PROGRAMS_STATUS.FETCHING);
 
-  return get('/programs/') // TODO replace with actual. Only guess at endpoint
+  return get('/programs')
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/programs/getPrograms): No response'; }
       if (response.ok &&
           response.body && response.body.data) {
+        Actions.programs.setStatus(PROGRAMS_STATUS.SUCCESS);
+        Actions.programs.setPrograms(response.body.data);
+
         return response.body.data;
       }
       throw 'ERROR (ducks/programs/getPrograms): Invalid response';
-    })
-    .then((data) => {
-      Actions.programs.setStatus(PROGRAMS_STATUS.SUCCESS);
-      Actions.programs.setPrograms(data);
-      return data;
     }).catch(error => handleError(error));
 });
 

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -10,10 +10,10 @@ const i2a = {
   staging: {
     id: '1',
     name: 'Astro 101 with Galaxy Zoo',
+    custom: false,
     description: 'Materials and tools for engaging introductory astronomy students in real research with Galaxy Zoo.',
-    slug: '/astro-101-with-galaxy-zoo',
+    slug: 'astro-101-with-galaxy-zoo',
     metadata: {
-      autoCreateAssignments: true,
       backgroundImage: 'astro-background.jpg',
       cardImage: 'home-card-intro-to-astro.jpg',
       redirectOnJoin: false,
@@ -44,10 +44,10 @@ const i2a = {
   production: {
     id: '1',
     name: 'Astro 101 with Galaxy Zoo',
+    custom: false,
     description: 'Materials and tools for engaging introductory astronomy students in real research with Galaxy Zoo.',
-    slug: '/astro-101-with-galaxy-zoo',
+    slug: 'astro-101-with-galaxy-zoo',
     metadata: {
-      autoCreateAssignments: true,
       backgroundImage: 'astro-background.jpg',
       cardImage: 'home-card-intro-to-astro.jpg',
       redirectOnJoin: false,
@@ -81,8 +81,9 @@ const darien = {
   staging: {
     id: '2',
     name: 'Wildcam Darien Lab',
+    custom: true,
     description: 'A map for exploring camera trap data from the WildCam Darien project.',
-    slug: '/wildcam-darien-lab',
+    slug: 'wildcam-darien-lab',
     metadata: {
       backgroundImage: '',
       cardImage: 'home-card-wildcam-darien.jpg',
@@ -92,8 +93,9 @@ const darien = {
   production: {
     id: '2',
     name: 'Wildcam Darien Lab',
+    custom: true,
     description: 'A map for exploring camera trap data from the WildCam Darien project.',
-    slug: '/wildcam-darien-lab',
+    slug: 'wildcam-darien-lab',
     metadata: {
       backgroundImage: '',
       cardImage: 'home-card-wildcam-darien.jpg',
@@ -127,7 +129,7 @@ const PROGRAMS_STATUS = {
 // Initial State and PropTypes - usable in React components.
 const PROGRAMS_INITIAL_STATE = {
   error: null,
-  programs: programsArray, // temporary
+  programs: [],
   selectedProgram: null,
   status: PROGRAMS_STATUS.IDLE
 };
@@ -193,7 +195,7 @@ Effect('getPrograms', () => {
 Effect('getProgram', (data) => {
   Actions.programs.setStatus(PROGRAMS_STATUS.FETCHING);
 
-  return Promise.resolve(data.programs.filter(program => program.slug === `/${data.param}`))
+  return Promise.resolve(data.programs.filter(program => program.slug === data.param))
     .then(([program]) => {
       Actions.programs.setStatus(PROGRAMS_STATUS.SUCCESS);
       Actions.programs.selectProgram(program);


### PR DESCRIPTION
Closes #49. We now have I2A and WD: Lab programs on the staging database. We can request them using the API. Note: the API show route for the programs is still authenticated, so you have to be logged in for this to work. I've opened zooniverse/education-api#69 about it.

Also, another idea on clearly communicating status: I've created the `GenericStatusPage`. This is a fall back page to show in case the server is down or the load time is really slow. I'm thinking some teachers may bookmark the I2A or Wildcam page and directly navigate to those pages. In case the status is still 'fetching' or 'error', The GenericStatusPage will display.

However, we have a lot of ways of communicating status. From Grommet's Toast and Notification components to now this. I may be going overboard with it. 