### PR TITLE
Classroom program link

### DIFF
--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -95,8 +95,8 @@ export class ClassroomFormContainer extends React.Component {
       Actions.createAssignment(assignmentData);
     })).then(() => {
       Actions.classrooms.toggleFormVisibility();
-      Actions.getClassroomsAndAssignments();
-    })
+      Actions.getClassroomsAndAssignments(this.props.selectedProgram);
+    });
   }
 
   render() {

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -38,14 +38,12 @@ export class ClassroomFormContainer extends React.Component {
 
   createClassroom() {
     const classroomData = {
-      data: {
-        attributes: this.props.formFields,
-        relationships: {
-          program: {
-            data: {
-              id: this.props.selectedProgram.id,
-              type: 'programs'
-            }
+      attributes: this.props.formFields,
+      relationships: {
+        program: {
+          data: {
+            id: this.props.selectedProgram.id,
+            type: 'programs'
           }
         }
       }
@@ -53,11 +51,9 @@ export class ClassroomFormContainer extends React.Component {
 
     Actions.createClassroom(classroomData)
       .then((classroom) => {
-        if (this.props.selectedProgram.metadata.autoCreateAssignments) {
+        if (!this.props.selectedProgram.custom) {
           const assignments = this.props.selectedProgram.metadata.assignments;
           if (classroom) this.autoCreateAssignments(assignments, classroom);
-        } else {
-          Actions.getClassroomsAndAssignments();
         }
       })
   }
@@ -79,21 +75,18 @@ export class ClassroomFormContainer extends React.Component {
       // Might have to include assigning the student to the assignments for I2A classrooms
       // on the join classroom action.
       const assignmentData = {
-        data: {
-          program_id: this.props.selectedProgram.id,
-          workflow_id: workflowId,
-          attributes: {
-            name: assignments[workflowId].name,
-            metadata: {
-              classification_target: assignments[workflowId].classification_target
-            }
-          },
-          relationships: {
-            classroom: {
-              data: {
-                id: classroom.id,
-                type: 'classrooms'
-              }
+        workflow_id: workflowId,
+        attributes: {
+          name: assignments[workflowId].name,
+          metadata: {
+            classification_target: assignments[workflowId].classification_target
+          }
+        },
+        relationships: {
+          classroom: {
+            data: {
+              id: classroom.id,
+              type: 'classrooms'
             }
           }
         }
@@ -101,11 +94,9 @@ export class ClassroomFormContainer extends React.Component {
 
       Actions.createAssignment(assignmentData);
     })).then(() => {
-      // For API optimization, we could merge the returned classroom into the local app state
-      // Then only call for the linked assignments for that one classroom
       Actions.classrooms.toggleFormVisibility();
       Actions.getClassroomsAndAssignments();
-    });
+    })
   }
 
   render() {

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -75,12 +75,12 @@ export class ClassroomFormContainer extends React.Component {
       // Might have to include assigning the student to the assignments for I2A classrooms
       // on the join classroom action.
       const assignmentData = {
-        workflow_id: workflowId,
         attributes: {
           name: assignments[workflowId].name,
           metadata: {
             classification_target: assignments[workflowId].classification_target
-          }
+          },
+          workflow_id: workflowId,
         },
         relationships: {
           classroom: {

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -15,8 +15,11 @@ export class ClassroomFormContainer extends React.Component {
   constructor(props) {
     super(props);
 
-    this.onSubmit = this.onSubmit.bind(this);
+    this.autoCreateAssignments = this.autoCreateAssignments.bind(this);
+    this.createClassroom = this.createClassroom.bind(this);
     this.onChange = this.onChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.updateClassroom = this.updateClassroom.bind(this);
   }
 
   onChange(event) {
@@ -26,61 +29,83 @@ export class ClassroomFormContainer extends React.Component {
 
   onSubmit(event) {
     event.preventDefault();
-    // TODO: Add project id(s) associated to classroom create
-
     if (this.props.selectedClassroom) {
-      Actions.updateClassroom({ id: this.props.selectedClassroom.id, payload: this.props.formFields })
-        .then(() => {
-          Actions.classrooms.toggleFormVisibility();
-        }).then(() => {
-          Actions.getClassroom(this.props.selectedClassroom.id);
-        });
+      this.updateClassroom();
     } else {
-      Actions.createClassroom(this.props.formFields)
-        .then((classroom) => {
-          console.log('classroom created', classroom)
-          if (this.props.selectedProgram.metadata.autoCreateAssignments) {
-            // TODO: Actions.assignments.createAssignment().then(Actions.getClassroomsAndAssignments());
-            // For API optimization, we could merge the returned classroom into the local app state
-            // Then only call for the linked assignments for that one classroom
-            const assignments = this.props.selectedProgram.metadata.assignments;
-            Promise.resolve(Object.keys(assignments).forEach((workflowId) => {
-              // The classroom creation action won't have any students yet.
-              // How do I later associate these auto-created assignments with the new classroom
-              // with students who join later?
-              // Might have to include assigning the student to the assignments for I2A classrooms
-              // on the join classroom action.
-              const assignmentData = {
-                data: {
-                  program_id: this.props.selectedProgram.id,
-                  workflow_id: workflowId,
-                  attributes: {
-                    name: assignments[workflowId].name,
-                    metadata: {
-                      classification_target: assignments[workflowId].classification_target
-                    }
-                  },
-                  relationships: {
-                    classroom: {
-                      data: {
-                        id: classroom.id,
-                        type: 'classrooms'
-                      }
-                    }
-                  }
-                }
-              };
-
-              Actions.createAssignment(assignmentData);
-            })).then(() => {
-              Actions.classrooms.toggleFormVisibility();
-              Actions.getClassroomsAndAssignments();
-            });
-          } else {
-            Actions.getClassroomsAndAssignments();
-          }
-        })
+      this.createClassroom();
     }
+  }
+
+  createClassroom() {
+    const classroomData = {
+      data: {
+        attributes: this.props.formFields,
+        relationships: {
+          program: {
+            data: {
+              id: this.props.selectedProgram.id,
+              type: 'programs'
+            }
+          }
+        }
+      }
+    };
+
+    Actions.createClassroom(classroomData)
+      .then((classroom) => {
+        if (this.props.selectedProgram.metadata.autoCreateAssignments) {
+          const assignments = this.props.selectedProgram.metadata.assignments;
+          if (classroom) this.autoCreateAssignments(assignments, classroom);
+        } else {
+          Actions.getClassroomsAndAssignments();
+        }
+      })
+  }
+
+  updateClassroom() {
+    Actions.updateClassroom({ id: this.props.selectedClassroom.id, payload: this.props.formFields })
+      .then(() => {
+        Actions.classrooms.toggleFormVisibility();
+      }).then(() => {
+        Actions.getClassroom(this.props.selectedClassroom.id);
+      });
+  }
+
+  autoCreateAssignments(assignments, classroom) {
+    Promise.resolve(Object.keys(assignments).forEach((workflowId) => {
+      // The classroom creation action won't have any students yet.
+      // How do I later associate these auto-created assignments with the new classroom
+      // with students who join later?
+      // Might have to include assigning the student to the assignments for I2A classrooms
+      // on the join classroom action.
+      const assignmentData = {
+        data: {
+          program_id: this.props.selectedProgram.id,
+          workflow_id: workflowId,
+          attributes: {
+            name: assignments[workflowId].name,
+            metadata: {
+              classification_target: assignments[workflowId].classification_target
+            }
+          },
+          relationships: {
+            classroom: {
+              data: {
+                id: classroom.id,
+                type: 'classrooms'
+              }
+            }
+          }
+        }
+      };
+
+      Actions.createAssignment(assignmentData);
+    })).then(() => {
+      // For API optimization, we could merge the returned classroom into the local app state
+      // Then only call for the linked assignments for that one classroom
+      Actions.classrooms.toggleFormVisibility();
+      Actions.getClassroomsAndAssignments();
+    });
   }
 
   render() {

--- a/src/containers/classrooms/ClassroomsManagerContainer.jsx
+++ b/src/containers/classrooms/ClassroomsManagerContainer.jsx
@@ -6,6 +6,9 @@ import ClassroomsManager from '../../components/classrooms/ClassroomsManager';
 import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
+import {
+  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
+} from '../../ducks/programs';
 
 export class ClassroomsManagerContainer extends React.Component {
   constructor(props) {
@@ -22,7 +25,13 @@ export class ClassroomsManagerContainer extends React.Component {
   }
 
   componentDidMount() {
-    Actions.getClassroomsAndAssignments();
+    if (this.props.selectedProgram) Actions.getClassroomsAndAssignments(this.props.selectedProgram);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.selectedProgram && this.props.selectedProgram !== nextProps.selectedProgram) {
+      Actions.getClassroomsAndAssignments(nextProps.selectedProgram);
+    }
   }
 
   componentWillUnmount() {
@@ -43,7 +52,7 @@ export class ClassroomsManagerContainer extends React.Component {
     Actions.deleteClassroom(this.state.classroomToDelete).then((response) => {
       // TODO: For API optimization, do we want to instead manually remove the classroom
       // out of local app state instead of making another API call
-      Actions.getClassroomsAndAssignments();
+      Actions.getClassroomsAndAssignments(this.props.selectedProgram);
       this.closeConfirmationDialog();
 
       if (response) {
@@ -71,11 +80,13 @@ export class ClassroomsManagerContainer extends React.Component {
 }
 
 ClassroomsManagerContainer.propTypes = {
-  ...CLASSROOMS_PROPTYPES
+  ...CLASSROOMS_PROPTYPES,
+  ...PROGRAMS_PROPTYPES
 };
 
 ClassroomsManagerContainer.defaultProps = {
-  ...CLASSROOMS_INITIAL_STATE
+  ...CLASSROOMS_INITIAL_STATE,
+  ...PROGRAMS_INITIAL_STATE
 };
 
 const mapStateToProps = (state) => ({
@@ -83,6 +94,7 @@ const mapStateToProps = (state) => ({
   classroomsStatus: state.classrooms.status,
   programs: state.programs.programs,
   selectedClassroom: state.classrooms.selectedClassroom,
+  selectedProgram: state.programs.selectedProgram,
   showConfirmationDialog: state.classrooms.showConfirmationDialog,
   showForm: state.classrooms.showForm
 });

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -69,7 +69,7 @@ Effect('getAssignments', (classroomId) => {
 Effect('createAssignment', (data) => {
   Actions.classrooms.setStatus(ASSIGNMENTS_STATUS.CREATING);
 
-  return post('/assignments', data)
+  return post('/assignments', { data })
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/assignments/createAssignment): No response'; }
       if (response.ok &&

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -92,7 +92,7 @@ const updateFormFields = (state, formFields) => {
 Effect('getClassrooms', (selectedProgramId) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.FETCHING);
 
-  return get('/teachers/classrooms/', [{ 'filter[programs]': selectedProgramId }])
+  return get('/teachers/classrooms/', [{ program_id: selectedProgramId }])
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
       if (response.ok &&

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -89,10 +89,10 @@ const updateFormFields = (state, formFields) => {
 };
 
 // Effects are for async actions and get automatically to the global Actions list
-Effect('getClassrooms', () => {
+Effect('getClassrooms', (selectedProgramId) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.FETCHING);
 
-  return get('/teachers/classrooms/')
+  return get('/teachers/classrooms/', [{ 'filter[programs]': selectedProgramId }])
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
       if (response.ok &&
@@ -133,8 +133,8 @@ Effect('getClassroom', (id) => {
     });
 });
 
-Effect('getClassroomsAndAssignments', () => {
-  Actions.getClassrooms().then((classrooms) => {
+Effect('getClassroomsAndAssignments', (selectedProgram) => {
+  Actions.getClassrooms(selectedProgram.id).then((classrooms) => {
     if (classrooms) {
       classrooms.forEach((classroom) => {
         // TODO: If many pages of assignments exist,

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -150,7 +150,7 @@ Effect('getClassroomsAndAssignments', () => {
 Effect('createClassroom', (data) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.CREATING);
 
-  return post('/teachers/classrooms/', { data: { attributes: data } })
+  return post('/teachers/classrooms/', { data })
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/createClassroom): No response'; }
       if (response.ok &&


### PR DESCRIPTION
For #72 and #54, this PR refactors the methods for creating a classroom and auto-creating the assignments for I2A classrooms. 
- Classroom creation now includes the program id in its relationship. This is to support filtering classrooms by program
- Auto-create assignments no longer needs the program id and the workflow id is sent in the attributes

This isn't fully working yet because of an API bug that is fixed in zooniverse/education-api#70 still needs to merge. 