### PR TITLE
Darien classrooms table

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -27,7 +27,7 @@ const AstroClassroomsTable = (props) => {
   return (
     <Box>
       <ExportModal onClose={props.onExportModalClose} assignment={props.assignmentToExport} />
-
+      {props.children}
       <Table className="manager-table">
         <thead className="manager-table__headers">
           <TableRow>

--- a/src/components/classrooms/ClassroomsManager.jsx
+++ b/src/components/classrooms/ClassroomsManager.jsx
@@ -13,7 +13,6 @@ import {
 } from '../../ducks/classrooms';
 
 import ClassroomFormContainer from '../../containers/classrooms/ClassroomFormContainer';
-import ConfirmationDialog from '../common/ConfirmationDialog';
 import ClassroomsTableContainer from '../../containers/classrooms/ClassroomsTableContainer';
 
 const ClassroomsManager = (props) => {
@@ -24,14 +23,6 @@ const ClassroomsManager = (props) => {
         <Paragraph align="start" size="small">{props.classroomInstructions}</Paragraph>
         <Button type="button" primary={true} label="Create New Classroom" onClick={props.toggleFormVisibility} />
       </Box>
-      <ConfirmationDialog
-        confirmationButtonLabel="Delete"
-        onConfirmation={props.deleteClassroom}
-        onClose={props.closeConfirmationDialog}
-        showConfirmationDialog={props.showConfirmationDialog}
-      >
-        <Paragraph size="small">Deleting a classroom will also delete the associated assignments.</Paragraph>
-      </ConfirmationDialog>
       {props.showForm &&
         <Layer closer={true} onClose={props.toggleFormVisibility}>
           <ClassroomFormContainer heading="Create Classroom" submitLabel="Create" />
@@ -43,19 +34,13 @@ const ClassroomsManager = (props) => {
       {props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.ERROR &&
         <Paragraph>Error: Classrooms could not be loaded.</Paragraph>}
       {(props.classrooms.length > 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) &&
-        <ClassroomsTableContainer
-          maybeDeleteClassroom={props.maybeDeleteClassroom}
-          match={props.match}
-        />}
+        <ClassroomsTableContainer match={props.match} />}
     </Box>
   );
 };
 
 ClassroomsManager.defaultProps = {
   classroomInstructions: 'First, make sure your students have set up a Zooniverse account. Then create a classroom and share the classroom\'s unique join URL with your students to keep track of their progress as they work through each assignment. Students must be logged in to their Zooniverse accounts first to be able to use the join link. Share the URL under View Project with your students for them to complete the assignment.',
-  closeConfirmationDialog: () => {},
-  deleteClassroom: () => {},
-  maybeDeleteClassroom: () => {},
   showForm: false,
   toggleFormVisibility: Actions.classrooms.toggleFormVisibility,
   ...CLASSROOMS_INITIAL_STATE
@@ -63,9 +48,6 @@ ClassroomsManager.defaultProps = {
 
 ClassroomsManager.propTypes = {
   classroomInstructions: PropTypes.string,
-  closeConfirmationDialog: PropTypes.func,
-  deleteClassroom: PropTypes.func,
-  maybeDeleteClassroom: PropTypes.func,
   showForm: PropTypes.bool,
   toggleFormVisibility: PropTypes.func,
   ...CLASSROOMS_PROPTYPES

--- a/src/components/darien/DarienClassroomsTable.jsx
+++ b/src/components/darien/DarienClassroomsTable.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Actions } from 'jumpstate';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import Box from 'grommet/components/Box';
+import Table from 'grommet/components/Table';
+import TableRow from 'grommet/components/TableRow';
+import AddIcon from 'grommet/components/icons/base/Add';
+import EditIcon from 'grommet/components/icons/base/Edit';
+import CloseIcon from 'grommet/components/icons/base/Close';
+import Anchor from 'grommet/components/Anchor';
+import Button from 'grommet/components/Button';
+import Paragraph from 'grommet/components/Paragraph';
+import Spinning from 'grommet/components/icons/Spinning';
+import Timestamp from 'grommet/components/Timestamp';
+
+import { config } from '../../lib/config';
+import {
+  ASSIGNMENTS_STATUS, ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
+} from '../../ducks/assignments';
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+
+const DarienClassroomsTable = (props) => {
+  return (
+    <Box>
+      <Table className="manager-table">
+        <thead className="manager-table__headers">
+          <TableRow>
+            <th id="assignments" scope="col" className="manager-table__caption">Your Classrooms</th>
+            <th id="completed" scope="col" className="headers__header">Completed</th>
+            <th id="export" scope="col" className="headers__header">Due Date</th>
+            <th id="view-project" scope="col" className="headers__header">View Project</th>
+          </TableRow>
+        </thead>
+        {props.classrooms.map((classroom) => {
+          // TODO update URL once we have staging/production hosts
+
+          const joinURL = `${window.location.host}/#/${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
+          // Can we get linked assignments with classrooms in single get request?
+          // No, if we want this, then we need to open an issue with the API
+          // TODO replace classifications_target with calculated percentage
+
+          // The trailing slash is inconsistent in React Router 4's match.url property...
+          const editURL = (props.match.url[props.match.url.length - 1] === '/') ? props.match.url : `${props.match.url}/`;
+          return (
+            <tbody className="manager-table__body" key={classroom.id}>
+              <TableRow>
+                <th className="manager-table__row-header" id="classroom" colSpan="4" scope="colgroup">
+                  <Box pad="none" margin="none" justify="between" direction="row">
+                    <span>
+                      <Button
+                        className="manager-table__button--edit"
+                        path={`${editURL}classrooms/${classroom.id}`}
+                        onClick={() => { Actions.classrooms.selectClassroom(classroom); }}
+                        icon={<EditIcon size="small" />}
+                      />
+                      {' '}{classroom.name}{' '}
+                      <CopyToClipboard text={joinURL} onCopy={() => { Actions.classrooms.setToastState({ status: 'ok', message: 'Copied join link.' }); }}>
+                        <Button type="button" className="manager-table__button--as-link" plain={true} onClick={() => {}}>
+                          Copy Join Link
+                        </Button>
+                      </CopyToClipboard>
+                    </span>
+                    <Button
+                      className="manager-table__button--delete"
+                      type="button"
+                      onClick={props.maybeDeleteClassroom.bind(null, classroom.id)}
+                    >
+                      <CloseIcon size="small" />
+                    </Button>
+                  </Box>
+                </th>
+              </TableRow>
+              {((props.assignments[classroom.id] &&
+                props.assignments[classroom.id].length === 0 &&
+                props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING) ||
+                (Object.keys(props.assignments).length === 0 &&
+                props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING)) &&
+                  <TableRow className="manager-table__row-data">
+                    <td colSpan="4"><Spinning /></td>
+                  </TableRow>}
+              {(props.assignments[classroom.id] &&
+                props.assignments[classroom.id].length === 0 &&
+                props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
+                <TableRow className="manager-table__row-data">
+                  <td colSpan="4">
+                    <Paragraph>No assignments have been created yet.</Paragraph>
+                    <Button
+                      className="manager-table__button--edit"
+                      onClick={props.toggleAssignmentForm}
+                      icon={<AddIcon size="small" />}
+                    />
+                  </td>
+                </TableRow>}
+              {(props.assignments[classroom.id] &&
+                props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
+                props.assignments[classroom.id].map((assignment) => {
+                  return (
+                    <TableRow className="manager-table__row-data" key={assignment.id}>
+                      <td headers="classroom assignments">
+                        {assignment.name}
+                        <Button
+                          className="manager-table__button--edit"
+                          onClick={props.toggleAssignmentForm}
+                          icon={<EditIcon size="small" />}
+                        />
+                      </td>
+                      <td headers="classroom completed">
+                        {(assignment.metadata && assignment.metadata.classifications_target) ?
+                          assignment.metadata.classifications_target : ''}
+                      </td>
+                      <td headers="classroom export">
+                        <Timestamp value={assignment.metadata.duedate} />
+                      </td>
+                      <td headers="classroom view-project">
+                        <Anchor
+                          className="manager-table__link"
+                          href={`${config.zooniverse}/projects/wildcam/wildcam-darien/classify?workflow=${assignment.workflow_id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Project Page{' '}
+                          <i className="fa fa-mail-forward" aria-hidden="true" />
+                          <Button
+                            className="manager-table__button--delete"
+                            type="button"
+                            onClick={props.maybeDeleteAssignment.bind(null, assignment.id)}
+                          >
+                            <CloseIcon size="small" />
+                          </Button>
+                        </Anchor>
+                      </td>
+                    </TableRow>
+                  );
+                })}
+            </tbody>
+          );
+        })}
+      </Table>
+    </Box>
+  );
+};
+
+DarienClassroomsTable.defaultProps = {
+  closeConfirmationDialog: () => {},
+  maybeDeleteAssignment: () => {},
+  maybeDeleteClassroom: () => {},
+  selectClassroom: () => {},
+  toggleAssignmentForm: () => {},
+  ...CLASSROOMS_INITIAL_STATE,
+  ...ASSIGNMENTS_INITIAL_STATE
+};
+
+DarienClassroomsTable.propTypes = {
+  closeConfirmationDialog: PropTypes.func,
+  maybeDeleteAssignment: PropTypes.func,
+  maybeDeleteClassroom: PropTypes.func,
+  selectClassroom: PropTypes.func,
+  toggleAssignmentForm: PropTypes.func,
+  ...CLASSROOMS_PROPTYPES,
+  ...ASSIGNMENTS_PROPTYPES
+};
+
+export default DarienClassroomsTable;

--- a/src/components/darien/DarienClassroomsTable.jsx
+++ b/src/components/darien/DarienClassroomsTable.jsx
@@ -25,6 +25,7 @@ import {
 const DarienClassroomsTable = (props) => {
   return (
     <Box>
+      {props.children}
       <Table className="manager-table">
         <thead className="manager-table__headers">
           <TableRow>

--- a/src/components/darien/DarienClassroomsTable.jsx
+++ b/src/components/darien/DarienClassroomsTable.jsx
@@ -86,12 +86,16 @@ const DarienClassroomsTable = (props) => {
                 props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
                 <TableRow className="manager-table__row-data">
                   <td colSpan="4">
-                    <Paragraph>No assignments have been created yet.</Paragraph>
-                    <Button
-                      className="manager-table__button--edit"
-                      onClick={props.toggleAssignmentForm}
-                      icon={<AddIcon size="small" />}
-                    />
+                    <Box pad="none" margin="none" justify="between" direction="row">
+                      <Paragraph>No assignments have been created yet.</Paragraph>
+                      <Button
+                        className="manager-table__button--create"
+                        onClick={props.toggleAssignmentForm}
+                        type="button"
+                      >
+                        <AddIcon size="small" />
+                      </Button>
+                    </Box>
                   </td>
                 </TableRow>}
               {(props.assignments[classroom.id] &&

--- a/src/components/darien/DarienHome.jsx
+++ b/src/components/darien/DarienHome.jsx
@@ -50,7 +50,7 @@ class DarienHome extends React.Component {
             <Paragraph>Are you an educator or a student/explorer? Make your selection to get started!</Paragraph>
           </Box>
           <Box align="center" direction="row" justify="between" pad="medium" size="medium">
-            <Button path="/wildcam-darien-lab/eduactors/" label="Educator" />
+            <Button path="/wildcam-darien-lab/educators/" label="Educator" />
             <Button path="/wildcam-darien-lab/students/" label="Explorer" />
           </Box>
         </Section>

--- a/src/containers/astro/AstroClassroomTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomTableContainer.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Actions } from 'jumpstate';
+import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
+
+class AstroClassroomsTableContainer extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      toExport: {
+        assignment: {},
+        classroom: {}
+      }
+    };
+
+    this.onExportModalClose = this.onExportModalClose.bind(this);
+    this.showExportModal = this.showExportModal.bind(this);
+  }
+
+  onExportModalClose() {
+    this.setState({ toExport: { assignment: {}, classroom: {} } });
+
+    Actions.caesarExports.showModal();
+  }
+
+  showExportModal(assignment, classroom) {
+    this.setState({ toExport: { assignment, classroom } });
+
+    Actions.caesarExports.showModal();
+    Actions.getCaesarExport({ assignment, classroom });
+  }
+
+  render() {
+    return (
+      <AstroClassroomsTable
+        {...this.props}
+        assignmentToExport={this.state.toExport.assignment}
+        onExportModalClose={this.onExportModalClose}
+        showExportModal={this.showExportModal}
+      >
+        {this.props.children}
+      </AstroClassroomsTable>
+    );
+  }
+}
+
+export default AstroClassroomsTableContainer;

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Actions } from 'jumpstate';
+import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
+
+class AstroClassroomsTableContainer extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      toExport: {
+        assignment: {},
+        classroom: {}
+      }
+    };
+
+    this.onExportModalClose = this.onExportModalClose.bind(this);
+    this.showExportModal = this.showExportModal.bind(this);
+  }
+
+  onExportModalClose() {
+    this.setState({ toExport: { assignment: {}, classroom: {} } });
+
+    Actions.caesarExports.showModal();
+  }
+
+  showExportModal(assignment, classroom) {
+    this.setState({ toExport: { assignment, classroom } });
+
+    Actions.caesarExports.showModal();
+    Actions.getCaesarExport({ assignment, classroom });
+  }
+
+  render() {
+    return (
+      <AstroClassroomsTable
+        {...this.props}
+        assignmentToExport={this.state.toExport.assignment}
+        onExportModalClose={this.onExportModalClose}
+        showExportModal={this.showExportModal}
+      >
+        {this.props.children}
+      </AstroClassroomsTable>
+    );
+  }
+}
+
+export default AstroClassroomsTableContainer;

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -55,7 +55,10 @@ export class ClassroomFormContainer extends React.Component {
           const assignments = this.props.selectedProgram.metadata.assignments;
           if (classroom) this.autoCreateAssignments(assignments, classroom);
         }
-      }).then(Actions.classrooms.toggleFormVisibility());
+      }).then(() => {
+        Actions.classrooms.toggleFormVisibility();
+        Actions.getClassroomsAndAssignments(this.props.selectedProgram);
+      });
   }
 
   updateClassroom() {
@@ -93,9 +96,7 @@ export class ClassroomFormContainer extends React.Component {
       };
 
       Actions.createAssignment(assignmentData);
-    })).then(() => {
-      Actions.getClassroomsAndAssignments(this.props.selectedProgram);
-    });
+    }));
   }
 
   render() {

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -55,7 +55,7 @@ export class ClassroomFormContainer extends React.Component {
           const assignments = this.props.selectedProgram.metadata.assignments;
           if (classroom) this.autoCreateAssignments(assignments, classroom);
         }
-      })
+      }).then(Actions.classrooms.toggleFormVisibility());
   }
 
   updateClassroom() {
@@ -94,7 +94,6 @@ export class ClassroomFormContainer extends React.Component {
 
       Actions.createAssignment(assignmentData);
     })).then(() => {
-      Actions.classrooms.toggleFormVisibility();
       Actions.getClassroomsAndAssignments(this.props.selectedProgram);
     });
   }

--- a/src/containers/classrooms/ClassroomsManagerContainer.jsx
+++ b/src/containers/classrooms/ClassroomsManagerContainer.jsx
@@ -11,19 +11,6 @@ import {
 } from '../../ducks/programs';
 
 export class ClassroomsManagerContainer extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      classroomToDelete: null,
-      showConfirmationDialog: false
-    };
-
-    this.closeConfirmationDialog = this.closeConfirmationDialog.bind(this);
-    this.deleteClassroom = this.deleteClassroom.bind(this);
-    this.maybeDeleteClassroom = this.maybeDeleteClassroom.bind(this);
-  }
-
   componentDidMount() {
     if (this.props.selectedProgram) Actions.getClassroomsAndAssignments(this.props.selectedProgram);
   }
@@ -38,41 +25,13 @@ export class ClassroomsManagerContainer extends React.Component {
     Actions.classrooms.setClassrooms(CLASSROOMS_INITIAL_STATE.classrooms);
   }
 
-  maybeDeleteClassroom(id) {
-    this.setState({ classroomToDelete: id, showConfirmationDialog: true });
-  }
-
-  closeConfirmationDialog() {
-    this.setState({ classroomToDelete: null, showConfirmationDialog: false });
-  }
-
-  deleteClassroom() {
-    if (this.state.classroomToDelete === null) return;
-
-    Actions.deleteClassroom(this.state.classroomToDelete).then((response) => {
-      // TODO: For API optimization, do we want to instead manually remove the classroom
-      // out of local app state instead of making another API call
-      Actions.getClassroomsAndAssignments(this.props.selectedProgram);
-      this.closeConfirmationDialog();
-
-      if (response) {
-        Actions.classrooms.setToastState({ status: 'ok', message: 'Classroom deleted' });
-      }
-    });
-  }
-
   render() {
     return (
       <ClassroomsManager
         classrooms={this.props.classrooms}
         classroomInstructions={this.props.classroomInstructions}
         classroomsStatus={this.props.classroomsStatus}
-        classroomToDelete={this.state.classroomToDelete}
-        closeConfirmationDialog={this.closeConfirmationDialog}
-        deleteClassroom={this.deleteClassroom}
         match={this.props.match}
-        maybeDeleteClassroom={this.maybeDeleteClassroom}
-        showConfirmationDialog={this.state.showConfirmationDialog}
         showForm={this.props.showForm}
       />
     );
@@ -95,7 +54,6 @@ const mapStateToProps = (state) => ({
   programs: state.programs.programs,
   selectedClassroom: state.classrooms.selectedClassroom,
   selectedProgram: state.programs.selectedProgram,
-  showConfirmationDialog: state.classrooms.showConfirmationDialog,
   showForm: state.classrooms.showForm
 });
 

--- a/src/containers/classrooms/ClassroomsTableContainer.jsx
+++ b/src/containers/classrooms/ClassroomsTableContainer.jsx
@@ -4,6 +4,8 @@ import { Actions } from 'jumpstate';
 import Paragraph from 'grommet/components/Paragraph';
 
 import ConfirmationDialog from '../../components/common/ConfirmationDialog';
+import DarienClassroomsTable from '../../components/darien/DarienClassroomsTable';
+import AstroClassroomsTableContainer from '../astro/AstroClassroomsTableContainer';
 import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
@@ -48,7 +50,8 @@ class ClassroomsTableContainer extends React.Component {
     });
   }
 
-  render() {
+  determineClassroomsTable() {
+    const ClassroomsTable = this.props.selectedProgram.custom ? DarienClassroomsTable : AstroClassroomsTableContainer;
     return (
       <ClassroomsTable
         assignments={this.props.assignments}
@@ -68,6 +71,10 @@ class ClassroomsTableContainer extends React.Component {
         </ConfirmationDialog>
       </ClassroomsTable>
     );
+  }
+
+  render() {
+    return (this.determineClassroomsTable());
   }
 }
 

--- a/src/containers/classrooms/ClassroomsTableContainer.jsx
+++ b/src/containers/classrooms/ClassroomsTableContainer.jsx
@@ -1,82 +1,84 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
-import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
+import Paragraph from 'grommet/components/Paragraph';
 
+import ConfirmationDialog from '../../components/common/ConfirmationDialog';
 import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
 import {
   ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
 } from '../../ducks/assignments';
-import { programsMocks } from '../../ducks/programs';
 
 class ClassroomsTableContainer extends React.Component {
   constructor() {
     super();
 
     this.state = {
-      toExport: {
-        assignment: {},
-        classroom: {}
-      }
+      classroomToDelete: null,
+      showConfirmationDialog: false
     };
 
-    this.onExportModalClose = this.onExportModalClose.bind(this);
-    this.showExportModal = this.showExportModal.bind(this);
+    this.closeConfirmationDialog = this.closeConfirmationDialog.bind(this);
+    this.deleteClassroom = this.deleteClassroom.bind(this);
+    this.maybeDeleteClassroom = this.maybeDeleteClassroom.bind(this);
   }
 
-  onExportModalClose() {
-    this.setState({ toExport: { assignment: {}, classroom: {} } });
-
-    Actions.caesarExports.showModal();
+  maybeDeleteClassroom(id) {
+    this.setState({ classroomToDelete: id, showConfirmationDialog: true });
   }
 
-  showExportModal(assignment, classroom) {
-    this.setState({ toExport: { assignment, classroom } });
-
-    Actions.caesarExports.showModal();
-    Actions.getCaesarExport({ assignment, classroom });
+  closeConfirmationDialog() {
+    this.setState({ classroomToDelete: null, showConfirmationDialog: false });
   }
 
-  selectClassroom(classroom) {
-    Actions.classrooms.selectClassroom(classroom);
+  deleteClassroom() {
+    if (this.state.classroomToDelete === null) return;
+
+    Actions.deleteClassroom(this.state.classroomToDelete).then((response) => {
+      // TODO: For API optimization, do we want to instead manually remove the classroom
+      // out of local app state instead of making another API call
+      Actions.getClassroomsAndAssignments();
+      this.closeConfirmationDialog();
+
+      if (response) {
+        Actions.classrooms.setToastState({ status: 'ok', message: 'Classroom deleted' });
+      }
+    });
   }
 
   render() {
-    if (this.props.selectedProgram && this.props.selectedProgram.slug === programsMocks.i2a.slug) {
-      return (
-        <AstroClassroomsTable
-          assignmentToExport={this.state.toExport.assignment}
-          assignments={this.props.assignments}
-          assignmentsStatus={this.props.assignmentsStatus}
-          classrooms={this.props.classrooms}
-          match={this.props.match}
-          maybeDeleteClassroom={this.props.maybeDeleteClassroom}
-          onExportModalClose={this.onExportModalClose}
-          selectClassroom={this.selectClassroom}
-          selectedProgram={this.props.selectedProgram}
-          showExportModal={this.showExportModal}
-        />
-      );
-    }
-
-    // TODO return the darien style classroom table
-    return null;
+    return (
+      <ClassroomsTable
+        assignments={this.props.assignments}
+        assignmentsStatus={this.props.assignmentsStatus}
+        classrooms={this.props.classrooms}
+        match={this.props.match}
+        maybeDeleteClassroom={this.props.maybeDeleteClassroom}
+        selectedProgram={this.props.selectedProgram}
+      >
+        <ConfirmationDialog
+          confirmationButtonLabel="Delete"
+          onConfirmation={this.deleteClassroom}
+          onClose={this.closeConfirmationDialog}
+          showConfirmationDialog={this.state.showConfirmationDialog}
+        >
+          <Paragraph size="small">Deleting a classroom will also delete the associated assignments.</Paragraph>
+        </ConfirmationDialog>
+      </ClassroomsTable>
+    );
   }
 }
 
 ClassroomsTableContainer.defaultProps = {
   ...ASSIGNMENTS_INITIAL_STATE,
-  ...CLASSROOMS_INITIAL_STATE,
-  selectClassroom: () => {}
+  ...CLASSROOMS_INITIAL_STATE
 };
 
 ClassroomsTableContainer.propTypes = {
   ...ASSIGNMENTS_PROPTYPES,
-  ...CLASSROOMS_PROPTYPES,
-  selectClassroom: PropTypes.func
+  ...CLASSROOMS_PROPTYPES
 };
 
 function mapStateToProps(state) {
@@ -89,3 +91,4 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps)(ClassroomsTableContainer);
+

--- a/src/containers/classrooms/ClassroomsTableContainer.jsx
+++ b/src/containers/classrooms/ClassroomsTableContainer.jsx
@@ -25,6 +25,15 @@ class ClassroomsTableContainer extends React.Component {
     this.closeConfirmationDialog = this.closeConfirmationDialog.bind(this);
     this.deleteClassroom = this.deleteClassroom.bind(this);
     this.maybeDeleteClassroom = this.maybeDeleteClassroom.bind(this);
+    this.resetState = this.resetState.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.resetState();
+  }
+
+  resetState() {
+    this.setState({ classroomToDelete: null, showConfirmationDialog: false });
   }
 
   maybeDeleteClassroom(id) {
@@ -32,7 +41,7 @@ class ClassroomsTableContainer extends React.Component {
   }
 
   closeConfirmationDialog() {
-    this.setState({ classroomToDelete: null, showConfirmationDialog: false });
+    this.resetState();
   }
 
   deleteClassroom() {
@@ -41,7 +50,7 @@ class ClassroomsTableContainer extends React.Component {
     Actions.deleteClassroom(this.state.classroomToDelete).then((response) => {
       // TODO: For API optimization, do we want to instead manually remove the classroom
       // out of local app state instead of making another API call
-      Actions.getClassroomsAndAssignments();
+      Actions.getClassroomsAndAssignments(this.props.selectedProgram);
       this.closeConfirmationDialog();
 
       if (response) {
@@ -58,7 +67,7 @@ class ClassroomsTableContainer extends React.Component {
         assignmentsStatus={this.props.assignmentsStatus}
         classrooms={this.props.classrooms}
         match={this.props.match}
-        maybeDeleteClassroom={this.props.maybeDeleteClassroom}
+        maybeDeleteClassroom={this.maybeDeleteClassroom}
         selectedProgram={this.props.selectedProgram}
       >
         <ConfirmationDialog

--- a/src/containers/common/ProgramHomeContainer.jsx
+++ b/src/containers/common/ProgramHomeContainer.jsx
@@ -51,11 +51,11 @@ export class ProgramHomeContainer extends React.Component {
     // Check RR v.4 docs
 
     if (this.props.programsStatus === PROGRAMS_STATUS.FETCHING) {
-      return (<GenericStatusPage status={this.props.programsStatus} message="Loading" />)
+      return (<GenericStatusPage status={this.props.programsStatus} message="Loading" />);
     }
 
     if (this.props.programsStatus === PROGRAMS_STATUS.ERROR) {
-      return (<GenericStatusPage status="critical" message="Something went wrong" />)
+      return (<GenericStatusPage status="critical" message="Something went wrong" />);
     }
 
     return (

--- a/src/containers/darien/DarienRoutesContainer.jsx
+++ b/src/containers/darien/DarienRoutesContainer.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import { Switch, Route } from 'react-router-dom';
 import DarienHome from '../../components/darien/DarienHome';
 import DarienExplorer from '../../components/darien/DarienExplorer';
+import ClassroomsLayout from '../../components/classrooms/ClassroomsLayout';
 
 export default class DarienRoutesContainer extends React.Component {
   render() {
     return (
       <Switch>
         <Route exact path={`${this.props.match.url}/`} component={DarienHome} />
+        <Route exact path={`${this.props.match.url}/educators`} component={ClassroomsLayout} />
         <Route exact path={`${this.props.match.url}/students`} component={DarienExplorer} />
       </Switch>
     );

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -92,11 +92,7 @@ const updateFormFields = (state, formFields) => {
 Effect('getClassrooms', (selectedProgramId) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.FETCHING);
 
-<<<<<<< a1176a69c771beaef9d5be1ab7b99fc292f79de9
   return get('/teachers/classrooms/', [{ program_id: selectedProgramId }])
-=======
-  return get('/teachers/classrooms/', [{ 'filter[programs]': selectedProgramId }])
->>>>>>> Add program filter
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
       if (response.ok &&

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -92,7 +92,11 @@ const updateFormFields = (state, formFields) => {
 Effect('getClassrooms', (selectedProgramId) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.FETCHING);
 
+<<<<<<< a1176a69c771beaef9d5be1ab7b99fc292f79de9
   return get('/teachers/classrooms/', [{ program_id: selectedProgramId }])
+=======
+  return get('/teachers/classrooms/', [{ 'filter[programs]': selectedProgramId }])
+>>>>>>> Add program filter
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
       if (response.ok &&

--- a/src/styles/components/classrooms-manager.styl
+++ b/src/styles/components/classrooms-manager.styl
@@ -51,6 +51,7 @@
 
     &__button--edit
     &__button--delete
+    &__button--create
       border: none
 
     .grommetux-table__table


### PR DESCRIPTION
This will have to merge after #73 because it is using the program filter for classrooms, so please ignore the changes that pertain to #73 until this is rebased.

This adds a view for the Darien educators page which is basically the classrooms manager which toggles between the table list view or the classroom editor. Darien's table will be slightly different than I2A's:
- the ability to create and edit assignments which I imagine will open a modal with a form like classroom create/edit does. Right now I just have placeholder buttons for creating and editing an assignment in the markup.
- The actual data in the table for the assignments. I replaced the export data column for the due date. 

I _really_ wanted to try to be clever with determining which classroom table to display by trying out some higher order components, but after puzzling on this for a while I ended up settling with a ternary. The nest of components to get down to the classrooms table is a bit convoluted and I'd really like to try to clean this up at some point as I'm finding it hard to follow myself and I wrote most of it. 

Part of the issue is React Router 4's new way of declarative routes, so there are a few components who's primary purpose is to contain the `<Switch />` and `<Routes />` for whatever nested routes they are.

The other issue is that Darien and I2A share all of the classroom components up until the table, so I couldn't figure out a clever way to have the routes programmatically determine the table since the table itself isn't going to be a route; it's just a child component of the `<ClassroomsManagerContainer />` component that is assigned to the `/educators/classrooms` route. The  I2A `/educators` also doesn't exist on its own; the I2A home page redirects to the educators page since they won't have a student interface. 

If you have any good ideas on how to make this better, I'm definitely open to it. 