### PR TITLE
Fix classroom form state

### DIFF
--- a/src/components/classrooms/ClassroomForm.jsx
+++ b/src/components/classrooms/ClassroomForm.jsx
@@ -35,7 +35,7 @@ const ClassroomForm = (props) => {
             placeHolder="Class subject"
             onDOMChange={props.onChange}
             required={!optional}
-            value={props.fields.subject}
+            value={props.fields.subject || ''}
           />
         </FormField>
         <FormField htmlFor="school" label="Institution">
@@ -44,7 +44,7 @@ const ClassroomForm = (props) => {
             placeHolder="Name of institution or school"
             onDOMChange={props.onChange}
             required={!optional}
-            value={props.fields.school}
+            value={props.fields.school || ''}
           />
         </FormField>
         <FormField htmlFor="description" label="Description">
@@ -53,7 +53,7 @@ const ClassroomForm = (props) => {
             placeholder="Description of class"
             onChange={props.onChange}
             required={!optional}
-            value={props.fields.description}
+            value={props.fields.description || ''}
           />
         </FormField>
       </fieldset>

--- a/src/components/darien/DarienClassroomsTable.jsx
+++ b/src/components/darien/DarienClassroomsTable.jsx
@@ -25,7 +25,10 @@ import {
 const DarienClassroomsTable = (props) => {
   return (
     <Box>
+<<<<<<< 969abec88131d532ea6e236c940c112daaeb8518
       {props.children}
+=======
+>>>>>>> Refactoring to enable Darien's classrooms table
       <Table className="manager-table">
         <thead className="manager-table__headers">
           <TableRow>
@@ -87,6 +90,7 @@ const DarienClassroomsTable = (props) => {
                 props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
                 <TableRow className="manager-table__row-data">
                   <td colSpan="4">
+<<<<<<< 969abec88131d532ea6e236c940c112daaeb8518
                     <Box pad="none" margin="none" justify="between" direction="row">
                       <Paragraph>No assignments have been created yet.</Paragraph>
                       <Button
@@ -97,6 +101,14 @@ const DarienClassroomsTable = (props) => {
                         <AddIcon size="small" />
                       </Button>
                     </Box>
+=======
+                    <Paragraph>No assignments have been created yet.</Paragraph>
+                    <Button
+                      className="manager-table__button--edit"
+                      onClick={props.toggleAssignmentForm}
+                      icon={<AddIcon size="small" />}
+                    />
+>>>>>>> Refactoring to enable Darien's classrooms table
                   </td>
                 </TableRow>}
               {(props.assignments[classroom.id] &&

--- a/src/components/darien/DarienClassroomsTable.jsx
+++ b/src/components/darien/DarienClassroomsTable.jsx
@@ -25,10 +25,7 @@ import {
 const DarienClassroomsTable = (props) => {
   return (
     <Box>
-<<<<<<< 969abec88131d532ea6e236c940c112daaeb8518
       {props.children}
-=======
->>>>>>> Refactoring to enable Darien's classrooms table
       <Table className="manager-table">
         <thead className="manager-table__headers">
           <TableRow>
@@ -90,7 +87,6 @@ const DarienClassroomsTable = (props) => {
                 props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
                 <TableRow className="manager-table__row-data">
                   <td colSpan="4">
-<<<<<<< 969abec88131d532ea6e236c940c112daaeb8518
                     <Box pad="none" margin="none" justify="between" direction="row">
                       <Paragraph>No assignments have been created yet.</Paragraph>
                       <Button
@@ -101,14 +97,6 @@ const DarienClassroomsTable = (props) => {
                         <AddIcon size="small" />
                       </Button>
                     </Box>
-=======
-                    <Paragraph>No assignments have been created yet.</Paragraph>
-                    <Button
-                      className="manager-table__button--edit"
-                      onClick={props.toggleAssignmentForm}
-                      icon={<AddIcon size="small" />}
-                    />
->>>>>>> Refactoring to enable Darien's classrooms table
                   </td>
                 </TableRow>}
               {(props.assignments[classroom.id] &&

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -18,8 +18,12 @@ export class ClassroomFormContainer extends React.Component {
     this.createClassroom = this.createClassroom.bind(this);
     this.onChange = this.onChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
-    this.resetState = this.resetState.bind(this);
+    this.closeForm = this.closeForm.bind(this);
     this.updateClassroom = this.updateClassroom.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.resetFormFields();
   }
 
   onChange(event) {
@@ -32,19 +36,22 @@ export class ClassroomFormContainer extends React.Component {
     if (this.props.selectedClassroom) {
       this.updateClassroom().then(() => {
         Actions.getClassroom(this.props.selectedClassroom.id);
-        this.resetState();
+        this.closeForm();
       });
     } else {
       this.createClassroom().then(() => {
         Actions.getClassroomsAndAssignments(this.props.selectedProgram);
-        this.resetState();
+        this.closeForm();
       });
     }
   }
 
-  resetState() {
-    Actions.classrooms.toggleFormVisibility();
+  resetFormFields() {
     Actions.classrooms.updateFormFields(CLASSROOMS_INITIAL_STATE.formFields);
+  }
+
+  closeForm() {
+    Actions.classrooms.toggleFormVisibility();
   }
 
   createClassroom() {

--- a/src/containers/classrooms/ClassroomsTableContainer.jsx
+++ b/src/containers/classrooms/ClassroomsTableContainer.jsx
@@ -6,6 +6,7 @@ import Paragraph from 'grommet/components/Paragraph';
 import ConfirmationDialog from '../../components/common/ConfirmationDialog';
 import DarienClassroomsTable from '../../components/darien/DarienClassroomsTable';
 import AstroClassroomsTableContainer from '../astro/AstroClassroomsTableContainer';
+
 import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -28,8 +28,20 @@ const ASSIGNMENTS_PROPTYPES = {
 function handleError(error) {
   Actions.assignments.setStatus(ASSIGNMENTS_STATUS.ERROR);
   Actions.assignments.setError(error);
-  Actions.notification.setNotification({ status: 'critical' , message: 'Something went wrong.' });
+  Actions.notification.setNotification({ status: 'critical', message: 'Something went wrong.' });
   console.error(error);
+}
+
+function sortAssignments(assignments) {
+  const firstAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.first);
+  const secondAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.second);
+  const thirdAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.third);
+
+  if (firstAssignment && secondAssignment && thirdAssignment) {
+    return [firstAssignment, secondAssignment, thirdAssignment];
+  }
+
+  return assignments;
 }
 
 // Synchonous actions
@@ -64,11 +76,7 @@ Effect('getAssignments', (data) => {
 
       // If I2A style program, then sort the assignments before setting them to the app state
       if (!data.selectedProgram.custom) {
-        const firstAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.first);
-        const secondAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.second);
-        const thirdAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.third);
-
-        assignmentsForClassroom[data.classroomId] = [firstAssignment, secondAssignment, thirdAssignment];
+        assignmentsForClassroom[data.classroomId] = sortAssignments(assignments);
       } else {
         assignmentsForClassroom[data.classroomId] = assignments;
       }

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -141,7 +141,7 @@ Effect('getClassroomsAndAssignments', (selectedProgram) => {
         // loop through the number of pages to request all of the data
         // and concatenate the response data together for the app state
         // Neither Pagination nor infinite scroll would be good UX for current table design.
-        Actions.getAssignments(classroom.id);
+        Actions.getAssignments({ classroomId: classroom.id, selectedProgram });
       });
     }
   });

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -92,11 +92,7 @@ const updateFormFields = (state, formFields) => {
 Effect('getClassrooms', (selectedProgramId) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.FETCHING);
 
-<<<<<<< a1176a69c771beaef9d5be1ab7b99fc292f79de9
   return get('/teachers/classrooms/', [{ program_id: selectedProgramId }])
-=======
-  return get('/teachers/classrooms/', [{ 'filter[programs]': selectedProgramId }])
->>>>>>> Add program filter
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
       if (response.ok &&

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -92,7 +92,11 @@ const updateFormFields = (state, formFields) => {
 Effect('getClassrooms', (selectedProgramId) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.FETCHING);
 
+<<<<<<< a1176a69c771beaef9d5be1ab7b99fc292f79de9
   return get('/teachers/classrooms/', [{ program_id: selectedProgramId }])
+=======
+  return get('/teachers/classrooms/', [{ 'filter[programs]': selectedProgramId }])
+>>>>>>> Add program filter
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }
       if (response.ok &&

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -6,6 +6,12 @@ import { get, post, put, httpDelete } from '../lib/edu-api';
 import { env } from '../lib/config';
 
 // testing mocks
+export const i2aAssignmentNames = {
+  first: "Introduction",
+  second: "Galaxy Zoo 101",
+  third: "Hubble's Law"
+}
+
 const i2a = {
   staging: {
     id: '1',
@@ -24,17 +30,17 @@ const i2a = {
         // to then build the URL to the project in the UI.
         // These are just test projects on staging...
         "2218": {
-          name: "Hubble's Law",
+          name: i2aAssignmentNames.third,
           classification_target: 10,
           slug: 'srallen086/intro2astro-hubble-testing'
         },
         "3037": {
-          name: 'Galaxy Zoo 101',
+          name: i2aAssignmentNames.second,
           classification_target: 22,
           slug: 'srallen086/galaxy-zoo-in-astronomy-101'
         },
         "3038": {
-          name: 'Introduction',
+          name: i2aAssignmentNames.first,
           classification_target: 1,
           slug: 'srallen086/introduction-to-platform'
         }
@@ -58,17 +64,17 @@ const i2a = {
         // to then build the URL to the project in the UI.
         // TODO: replace the workflow ids here with the production ids
         "1315": {
-          name: "Hubble's Law",
+          name: i2aAssignmentNames.third,
           classification_target: 10,
           slug: 'srallen086/intro2astro-hubble-testing'
         },
         "1771": {
-          name: 'Galaxy Zoo 101',
+          name: i2aAssignmentNames.second,
           classification_target: 22,
           slug: 'srallen086/galaxy-zoo-in-astronomy-101'
         },
         "3038": {
-          name: 'Introduction',
+          name: i2aAssignmentNames.first,
           classification_target: 1,
           slug: 'srallen086/introduction-to-platform'
         }

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -14,5 +14,6 @@
   <body>
     <div id="root"></div>
     <%= htmlWebpackPlugin.options.gtm %>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find&amp;flags=gated"></script>
   </body>
 </html>


### PR DESCRIPTION
This does two things:

- Fixes a possible regression I introduced that I noticed while debugging #74 
  - The classroom create/edit form wasn't clearing out the form fields on unmount, so when you created a classroom and then clicked to create another (or edit), the form field had the previous content.
- This also adds a consistent sort order for the I2A assignments