### PR TITLE
Move route for join page up a switch statement

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -10,6 +10,8 @@ import AdminContainer from '../containers/layout/AdminContainer';
 import AuthContainer from '../containers/layout/AuthContainer';
 import AppNotification from '../containers/layout/AppNotification';
 import ProgramHomeContainer from '../containers/common/ProgramHomeContainer';
+import JoinPageContainer from '../containers/common/JoinPageContainer';
+
 import AppHeader from './layout/AppHeader';
 import {
   removeLocation,
@@ -42,6 +44,7 @@ const Main = ({ admin, location }) => {
         <AppNotification />
         <Switch>
           <Route exact path="/" component={HomeContainer} />
+          <Route exact path="/:program/students/classrooms/:classroomId/join" component={JoinPageContainer} />
           <Route path="/:program" component={ProgramHomeContainer} />
         </Switch>
         <ZooFooter adminContainer={<AdminContainer />} />

--- a/src/containers/common/ProgramHomeContainer.jsx
+++ b/src/containers/common/ProgramHomeContainer.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
-import JoinPageContainer from './JoinPageContainer';
 import AstroHome from '../../components/astro/AstroHome';
 import DarienRoutesContainer from '../darien/DarienRoutesContainer';
 import GenericStatusPage from '../../components/common/GenericStatusPage';
@@ -23,7 +22,7 @@ export class ProgramHomeContainer extends React.Component {
   componentDidMount() {
     if (this.props.programs.length === 0 && !this.props.selectedProgram) {
       Actions.getPrograms().then((programs) => {
-        this.getProgram(programs, this.props.match.params.program)
+        this.getProgram(programs, this.props.match.params.program);
       });
     }
 
@@ -60,7 +59,6 @@ export class ProgramHomeContainer extends React.Component {
 
     return (
       <Switch>
-        <Route path="/:program/students/classrooms/:classroomId/join" component={JoinPageContainer} />
         <Route path="/astro-101-with-galaxy-zoo/educators" component={AstroHome} />
         <Redirect from="/astro-101-with-galaxy-zoo" to="/astro-101-with-galaxy-zoo/educators/" />
         <Route path="/wildcam-darien-lab" component={DarienRoutesContainer} />


### PR DESCRIPTION
The route for the join classroom page was broken. The `Switch` component was supposed to be handling the matching order and I thought the join page would be matched first, but the redirect was for some reason. I don't understand, but moving the join route up a level fixed it. 