### PR TITLE
Use program mock as fallback

### DIFF
--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -193,7 +193,14 @@ Effect('getPrograms', () => {
         return response.body.data;
       }
       throw 'ERROR (ducks/programs/getPrograms): Invalid response';
-    }).catch(error => handleError(error));
+    }).catch((error) => {
+      if (error.status !== 404) handleError(error)
+      if (error.status === 404) {
+        // Fallback to showing the mocks
+        Actions.programs.setStatus(PROGRAMS_STATUS.SUCCESS);
+        Actions.programs.setPrograms(programsArray);
+      }
+    });
 });
 
 Effect('getProgram', (data) => {

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -194,9 +194,11 @@ Effect('getPrograms', () => {
       }
       throw 'ERROR (ducks/programs/getPrograms): Invalid response';
     }).catch((error) => {
-      if (error.status !== 404) handleError(error)
+      if (error.status !== 404) handleError(error);
       if (error.status === 404) {
         // Fallback to showing the mocks
+        // This is temporary until the production API is deployed with programs support.
+        console.log('Programs set in the redux store are the mocks');
         Actions.programs.setStatus(PROGRAMS_STATUS.SUCCESS);
         Actions.programs.setPrograms(programsArray);
       }


### PR DESCRIPTION
This updates the error handler for requesting the programs. If it 404s, like it currently does in production since the back end API hasn't been deployed yet and still has no notion of a program, then it'll fallback to the programs mocks. 