### PR TITLE
Remove intro assignment

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -35,7 +35,7 @@ const Main = ({ admin, location }) => {
   }
 
   return (
-    <App centered={false} className="app-layout" inline={true}>
+    <App centered={false} className="app-layout">
       {admin &&
         <AdminLayoutIndicator />}
       <Box>

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -76,7 +76,8 @@ const AstroClassroomsTable = (props) => {
                 props.assignments[classroom.id].length === 0 &&
                 props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING) ||
                 (Object.keys(props.assignments).length === 0 &&
-                props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING)) &&
+                props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING)) ||
+                (props.assignmentsStatus === ASSIGNMENTS_STATUS.CREATING) &&
                   <TableRow className="manager-table__row-data">
                     <td colSpan="4"><Spinning /></td>
                   </TableRow>}
@@ -87,6 +88,7 @@ const AstroClassroomsTable = (props) => {
                   <td colSpan="4"><Paragraph>No assignments have been created yet.</Paragraph></td>
                 </TableRow>}
               {(props.assignments[classroom.id] &&
+                props.assignments[classroom.id].length > 0 &&
                 props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS) &&
                 props.assignments[classroom.id].map((assignment) => {
                   const projectUrl = (assignmentsMetadata && assignmentsMetadata[assignment.workflowId]) ?

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -35,10 +35,9 @@ function handleError(error) {
 function sortAssignments(assignments) {
   const firstAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.first);
   const secondAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.second);
-  const thirdAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.third);
 
-  if (firstAssignment && secondAssignment && thirdAssignment) {
-    return [firstAssignment, secondAssignment, thirdAssignment];
+  if (firstAssignment && secondAssignment) {
+    return [firstAssignment, secondAssignment];
   }
 
   return assignments;

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -87,7 +87,7 @@ Effect('getAssignments', (data) => {
 });
 
 Effect('createAssignment', (data) => {
-  Actions.classrooms.setStatus(ASSIGNMENTS_STATUS.CREATING);
+  Actions.assignments.setStatus(ASSIGNMENTS_STATUS.CREATING);
 
   return post('/assignments', { data })
     .then((response) => {

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -141,7 +141,12 @@ Effect('getClassroomsAndAssignments', (selectedProgram) => {
         // loop through the number of pages to request all of the data
         // and concatenate the response data together for the app state
         // Neither Pagination nor infinite scroll would be good UX for current table design.
-        Actions.getAssignments({ classroomId: classroom.id, selectedProgram });
+
+        // Sometimes the request to get assignments after the classroom create returns null
+        // even though a successful create happens. Give it some time...
+        // Probably a better way to deal with this.
+        // Maybe we should start using async/await?
+        setTimeout(() => { Actions.getAssignments({ classroomId: classroom.id, selectedProgram }); }, 500);
       });
     }
   });

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -7,9 +7,8 @@ import { env } from '../lib/config';
 
 // testing mocks
 export const i2aAssignmentNames = {
-  first: "Introduction",
-  second: "Galaxy Zoo 101",
-  third: "Hubble's Law"
+  first: "Galaxy Zoo 101",
+  second: "Hubble's Law"
 }
 
 const i2a = {
@@ -30,19 +29,14 @@ const i2a = {
         // to then build the URL to the project in the UI.
         // These are just test projects on staging...
         "2218": {
-          name: i2aAssignmentNames.third,
-          classification_target: 10,
+          name: i2aAssignmentNames.second,
+          classifications_target: "10",
           slug: 'srallen086/intro2astro-hubble-testing'
         },
         "3037": {
-          name: i2aAssignmentNames.second,
-          classification_target: 22,
-          slug: 'srallen086/galaxy-zoo-in-astronomy-101'
-        },
-        "3038": {
           name: i2aAssignmentNames.first,
-          classification_target: 1,
-          slug: 'srallen086/introduction-to-platform'
+          classifications_target: "22",
+          slug: 'srallen086/galaxy-zoo-in-astronomy-101'
         }
       }
     }
@@ -64,19 +58,14 @@ const i2a = {
         // to then build the URL to the project in the UI.
         // TODO: replace the workflow ids here with the production ids
         "1315": {
-          name: i2aAssignmentNames.third,
-          classification_target: 10,
+          name: i2aAssignmentNames.second,
+          classifications_target: "10",
           slug: 'srallen086/intro2astro-hubble-testing'
         },
         "1771": {
-          name: i2aAssignmentNames.second,
-          classification_target: 22,
-          slug: 'srallen086/galaxy-zoo-in-astronomy-101'
-        },
-        "3038": {
           name: i2aAssignmentNames.first,
-          classification_target: 1,
-          slug: 'srallen086/introduction-to-platform'
+          classifications_target: "22",
+          slug: 'srallen086/galaxy-zoo-in-astronomy-101'
         }
       }
     }


### PR DESCRIPTION
It's been decided that the introductory assignment wasn't a good fit for use of the Zooniverse's project builder and platform. This PR removes it. WIP because staging API is on the fritz at the moment and the programs in the database still need updating. I also fix a typo and make the classifications_target a string since that's what they actually are on assignments. I fixed this in #76, but this is a better fit for updating this. I'll rebase #76 after this merges. 