### PR TITLE
Real stats prep

### DIFF
--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -58,9 +58,10 @@ const ExportModal = ({ caesarExport, caesarExportStatus, onClose, showModal }) =
           <Box direction="row">
             <SuperDownloadButton
               className="export-modal__button"
-              text="Download CSV"
-              primary={true}
               disabled={disableButton}
+              fileNameBase="astro101-"
+              primary={true}
+              text="Download CSV"
             />
             <GoogleDriveExportButton className="export-modal__button" />
           </Box>

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -159,7 +159,6 @@ const ClassroomEditor = (props) => {
           <thead className="manager-table__headers">
             <TableRow>
               <th id="student-name" scope="col" className="headers__header">Student Name/Zooniverse ID</th>
-              <th id="assignment-intro" scope="col" className="headers__header">Introduction</th>
               <th id="assignment-galaxy" scope="col" className="headers__header">Galaxy Zoo 101</th>
               <th id="assignment-hubble" scope="col" className="headers__header">Hubble's Law</th>
               <th id="student-remove" scope="col" className="headers__header">Remove Student</th>
@@ -173,7 +172,9 @@ const ClassroomEditor = (props) => {
               </TableRow>
             )}
 
-            {props.assignmentsStatus !== ASSIGNMENTS_STATUS.FETCHING &&
+            {props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS &&
+            props.assignments[props.selectedClassroom.id] &&
+            props.assignments[props.selectedClassroom.id].length > 0 &&
               students.map(student =>
                 (<TableRow className="manager-table__row-data" key={`classroom-student-${student.id}`}>
                   <td headers="student-name">
@@ -181,7 +182,6 @@ const ClassroomEditor = (props) => {
                       ? <span>{student.zooniverseDisplayName}</span>
                       : <span className="secondary">{student.zooniverseLogin}</span> }
                   </td>
-                  <td headers="assignment-intro">{Math.floor(Math.random() * 100)}%</td>
                   <td headers="assignment-galaxy">{Math.floor(Math.random() * 100)}%</td>
                   <td headers="assignment-hubble">{Math.floor(Math.random() * 100)}%</td>
                   <td headers="student-remove">

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import { saveAs } from 'browser-filesaver';
 import ClassroomEditor from '../../components/classrooms/ClassroomEditor';
-import { blobbifyData, generateFilename } from '../../lib/mapexplorer-helpers'; // TODO: Maybe not brand this as 'mapexplorer'?
+import { blobbifyData, generateFilename } from '../../lib/file-download-helpers';
 
 import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -34,16 +34,27 @@ export class ClassroomEditorContainer extends React.Component {
     this.removeStudentFromClassroom = this.removeStudentFromClassroom.bind(this);
   }
 
+  componentDidMount() {
+    if (this.props.selectedProgram && !this.props.selectedClassroom) {
+      this.getClassroomAndAssignments(this.props);
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.selectedProgram &&
         this.props.selectedProgram !== nextProps.selectedProgram &&
         !this.props.selectedClassroom) {
-      Actions.getClassroom(this.props.match.params.id);
+      this.getClassroomAndAssignments(nextProps);
     }
   }
 
   componentWillUnmount() {
     Actions.classrooms.selectClassroom(CLASSROOMS_INITIAL_STATE.selectedClassroom);
+  }
+
+  getClassroomAndAssignments(props) {
+    Actions.getClassroom(props.match.params.id)
+      .then(classroom => Actions.getAssignments({ classroomId: classroom.id, selectedProgram: props.selectedProgram }));
   }
 
   editClassroom() {

--- a/src/containers/maps/MapControls.jsx
+++ b/src/containers/maps/MapControls.jsx
@@ -37,20 +37,20 @@ class MapControls extends React.Component {
   constructor(props) {
     super(props);
   }
-  
+
   //----------------------------------------------------------------
 
   render() {
     if (!this.props.mapConfig) return null;
-    
+
     const mapConfig = this.props.mapConfig;
-    
+
     const where = constructWhereClause(mapConfig, this.props.filters);
     const downloadUrl = mapConfig.database.urls.csv.replace(
       '{SQLQUERY}',
       encodeURIComponent(mapConfig.database.queries.selectForDownload.replace('{WHERE}', where))
     );
-    
+
     const hasAnySelections = this.props.filters && Object.keys(this.props.filters).length > 0;
     let statusMessage = '...';
     if (this.props.markersStatus === MAPEXPLORER_MARKERS_STATUS.FETCHING) {
@@ -60,14 +60,15 @@ class MapControls extends React.Component {
     } else if (this.props.markersStatus === MAPEXPLORER_MARKERS_STATUS.SUCCESS) {
       statusMessage = `${this.props.markersDataCount} ${ZooTran('result(s)')}`;
     }
-    
+
     const lang = ZooTranGetLanguage();
-    
+
     return (
       <Box className="map-controls">
         <Accordion openMulti={true}>
           <AccordionPanel heading={statusMessage} className="map-controls-status">
             <SuperDownloadButton
+              fileNameBase="wildcam-"
               url={downloadUrl}
               text={ZooTran('Download')}
               useZooniversalTranslator={true}
@@ -120,7 +121,7 @@ class MapControls extends React.Component {
       </Box>
     );
   }
-  
+
   componentWillReceiveProps(props = this.props) {
     //Prevent infinite loops; only update when the selected filters are changed.
     let areFiltersDifferent = JSON.stringify(this.props.filters) !== JSON.stringify(props.filters);

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -60,6 +60,7 @@ const setError = (state, error) => {
 // Effects are for async actions and get automatically to the global Actions list
 Effect('getAssignments', (data) => {
   Actions.assignments.setStatus(ASSIGNMENTS_STATUS.FETCHING);
+
   return get('/assignments', [{ classroom_id: data.classroomId }])
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/getClassrooms): No response'; }

--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -126,8 +126,6 @@ Effect('getClassroom', (id) => {
       Actions.classrooms.setStatus(CLASSROOMS_STATUS.SUCCESS);
       Actions.classrooms.selectClassroom(classroom);
       return classroom;
-    }).then((classroom) => {
-      Actions.getAssignments(classroom.id);
     }).catch((error) => {
       handleError(error);
     });

--- a/src/lib/file-download-helpers.js
+++ b/src/lib/file-download-helpers.js
@@ -1,0 +1,20 @@
+/*  Auto-generated a filename, for downloading purposes.
+ */
+export function generateFilename(basename = 'download-', extension = '.csv') {
+  let timeString = new Date();
+  timeString =
+    timeString.getDate() +
+    ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][timeString.getMonth()] +
+    timeString.getFullYear();
+  return basename + timeString + extension;
+}
+
+/*  Transforms data into a blobby blob for downloading purposes.
+ */
+export function blobbifyData(data, contentType = 'text/csv') {
+  if (data) {
+    let dataBlob = new Blob([data], {type: contentType});
+    return dataBlob;
+  }
+  return null;
+}

--- a/src/lib/mapexplorer-helpers.js
+++ b/src/lib/mapexplorer-helpers.js
@@ -12,15 +12,15 @@ This library contains general utility functions required by the Map Explorer.
 export function constructWhereClause(mapConfig, selectedFilters) {
   if (!mapConfig || !mapConfig.map || !mapConfig.map.filters || !selectedFilters)
     return '';
-  
+
   let sqlWhere = '';
-  
+
   const keys = Object.keys(selectedFilters);
-  
+
   //For each filter type...
   let sqlSelectedFilters = keys.map((key) => {
     const filter = mapConfig.map.filters[key];
-    
+
     if (filter.type === 'multichoice') {
       let sqlSelectedOptions = selectedFilters[key].map(val => `${sqlString(key)} LIKE '${sqlString(val)}'`);
       sqlSelectedOptions = sqlSelectedOptions.join(' OR ');
@@ -30,35 +30,14 @@ export function constructWhereClause(mapConfig, selectedFilters) {
 
     return '(1 = 1)';  //Default true statement
   });
-  
+
   sqlWhere = sqlSelectedFilters.join(' AND ');
-  
+
   if (sqlWhere !== '') sqlWhere = ' WHERE ' + sqlWhere + ' ';
-  
+
   return sqlWhere;
 }
 
 export function sqlString(str) {
   return str.replace(/'/ig, "''");
-}
-
-/*  Auto-generated a filename, for downloading purposes.
- */
-export function generateFilename(basename = 'wildcam-', extension = '.csv') {
-  let timeString = new Date();
-  timeString =
-    timeString.getDate() +
-    ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][timeString.getMonth()] +
-    timeString.getFullYear();
-  return basename + timeString + extension;
-}
-
-/*  Transforms data into a blobby blob for downloading purposes.
- */
-export function blobbifyData(data, contentType = 'text/csv') {
-  if (data) {
-    let dataBlob = new Blob([data], {type: contentType});
-    return dataBlob;
-  }
-  return null;
 }


### PR DESCRIPTION
For #67, in anticipation of using real stats for the student's progress, this PR
- Extracts `blobbifyData` and `generateFileName` into its own helper js file to be shared between Darien and I2A
- Removes the Introduction assignment from the table since that won't be a Zooniverse project now
- Makes the download csv file name prefix a prop for the SuperDownloadButton
- Fixes the TypeError seen on the classroom edit page when assignments were requested
- Fixes linter errors in SuperDownloadButton

Question about the SuperDownloadButton:
We officially only support the current version and last previous version of browser. For Safari, that's now version 10 and 11. Do we still need the work around written in the SuperDownloadButton for Safari?