### PR TITLE
Export stats

### DIFF
--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -106,7 +106,12 @@ const ClassroomEditor = (props) => {
             <Button type="button" label="Copy Join Link" />
           </CopyToClipboard>
 
-          <Button type="button" primary={true} label="Export Grades" onClick={props.exportGrades} />
+          <Button
+            type="button"
+            primary={true}
+            label="Export Stats"
+            onClick={props.selectedClassroom && props.selectedClassroom.students.length > 0 ? props.exportStats : null}
+          />
         </Box>
 
         <Box
@@ -177,9 +182,9 @@ const ClassroomEditor = (props) => {
             props.assignments[props.selectedClassroom.id] &&
             props.assignments[props.selectedClassroom.id].length > 0 &&
               students.map((student) => {
-                const galaxyAssignment = props.assignments[props.selectedClassroom.id].filter(
+                const galaxyAssignment = assignments.filter(
                   assignment => assignment.name === i2aAssignmentNames.first);
-                const hubbleAssignment = props.assignments[props.selectedClassroom.id].filter(
+                const hubbleAssignment = assignments.filter(
                   assignment => assignment.name === i2aAssignmentNames.second);
 
                 // Why are the ids in the student_user_id property numbers?!?!?!
@@ -218,6 +223,7 @@ const ClassroomEditor = (props) => {
 
 ClassroomEditor.defaultProps = {
   editClassroom: () => {},
+  exportStates: () => {},
   selectClassroom: () => {},
   removeStudentFromClassroom: () => {},
   //----------------
@@ -229,6 +235,7 @@ ClassroomEditor.defaultProps = {
 
 ClassroomEditor.propTypes = {
   editClassroom: PropTypes.func,
+  exportStats: PropTypes.func,
   selectClassroom: PropTypes.func,
   removeStudentFromClassroom: PropTypes.func,
   //----------------

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -223,7 +223,7 @@ const ClassroomEditor = (props) => {
 
 ClassroomEditor.defaultProps = {
   editClassroom: () => {},
-  exportStates: () => {},
+  exportStats: () => {},
   selectClassroom: () => {},
   removeStudentFromClassroom: () => {},
   //----------------

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -12,7 +12,7 @@ import {
   ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
 } from '../../ducks/assignments';
 import {
-  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
+  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES, i2aAssignmentNames
 } from '../../ducks/programs';
 
 export class ClassroomEditorContainer extends React.Component {
@@ -29,7 +29,7 @@ export class ClassroomEditorContainer extends React.Component {
 
     this.closeConfirmationDialog = this.closeConfirmationDialog.bind(this);
     this.editClassroom = this.editClassroom.bind(this);
-    this.exportGrades = this.exportGrades.bind(this);
+    this.exportStats = this.exportStats.bind(this);
     this.maybeRemoveStudentFromClassroom = this.maybeRemoveStudentFromClassroom.bind(this);
     this.removeStudentFromClassroom = this.removeStudentFromClassroom.bind(this);
   }
@@ -72,25 +72,38 @@ export class ClassroomEditorContainer extends React.Component {
     return null;
   }
 
-  exportGrades() {
-    if (!this.props.selectedClassroom) return null;
+  exportStats() {
+    if (!this.props.selectedClassroom && !this.props.selectedClassroom.students) return null;
+    const classroomName = this.props.selectedClassroom.name;
+    const galaxyAssignment = this.props.assignments[this.props.selectedClassroom.id].filter(
+      assignment => assignment.name === i2aAssignmentNames.first);
+    const hubbleAssignment = this.props.assignments[this.props.selectedClassroom.id].filter(
+      assignment => assignment.name === i2aAssignmentNames.second);
+    const galaxyClassificationTarget = galaxyAssignment[0].metadata.classifications_target;
+    const hubbleClassificationTarget = hubbleAssignment[0].metadata.classifications_target;
 
-    //TODO
-    //--------------------------------
-    let exampleData = 'id,name\n';
-    this.props.selectedClassroom.students &&
+    let exampleData = 'classroom,name,Galaxy Zoo 101 classification count,Hubble\'s Law classification count,Galaxy Zoo 101 percentage complete,Hubble\'s Law percentage complete\n';
+
     this.props.selectedClassroom.students.map((student) => {
       let studentName = (student.zooniverseDisplayName && student.zooniverseDisplayName.length > 0)
         ? student.zooniverseDisplayName
         : String(student.zooniverseLogin);
+
       studentName = studentName.replace(/"/g, '""');
-      const row = `${student.id},"${studentName}"\n`;
+      const galaxyStudentData = galaxyAssignment[0].studentAssignmentsData.filter(
+        data => data.attributes.student_user_id.toString() === student.id);
+      const hubbleStudentData = hubbleAssignment[0].studentAssignmentsData.filter(
+        data => data.attributes.student_user_id.toString() === student.id);
+      const studentGalaxyCount = galaxyStudentData[0].attributes.classifications_count;
+      const studentHubbleCount = hubbleStudentData[0].attributes.classifications_count;
+      const galaxyCountStat = `${studentGalaxyCount}/${galaxyClassificationTarget}`;
+      const hubbleCountStat = `${studentHubbleCount}/${hubbleClassificationTarget}`
+      const galaxyPercentageStat = (studentGalaxyCount / (+galaxyClassificationTarget)) * 100;
+      const hubblePercentageStat = (studentHubbleCount / (+hubbleClassificationTarget)) * 100;
+      const row = `"${classroomName}","${studentName}",${galaxyCountStat},${hubbleCountStat},${galaxyPercentageStat},${hubblePercentageStat}\n`;
       exampleData += row;
     });
     saveAs(blobbifyData(exampleData, this.props.contentType), generateFilename('astro-', '.csv'));
-
-    alert('TODO! Create a proper Export Grades function.');
-    //--------------------------------
   }
 
   maybeRemoveStudentFromClassroom(classroomId, studentId) {
@@ -122,7 +135,7 @@ export class ClassroomEditorContainer extends React.Component {
         classroomsStatus={this.props.classroomsStatus}
         closeConfirmationDialog={this.closeConfirmationDialog}
         editClassroom={this.editClassroom}
-        exportGrades={this.exportGrades}
+        exportStats={this.exportStats}
         match={this.props.match}
         maybeRemoveStudentFromClassroom={this.maybeRemoveStudentFromClassroom}
         removeStudentFromClassroom={this.removeStudentFromClassroom}

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -82,7 +82,7 @@ export class ClassroomEditorContainer extends React.Component {
     const galaxyClassificationTarget = galaxyAssignment[0].metadata.classifications_target;
     const hubbleClassificationTarget = hubbleAssignment[0].metadata.classifications_target;
 
-    let exampleData = 'classroom,name,Galaxy Zoo 101 classification count,Hubble\'s Law classification count,Galaxy Zoo 101 percentage complete,Hubble\'s Law percentage complete\n';
+    let csvData = 'classroom,name,Galaxy Zoo 101 classification count,Hubble\'s Law classification count,Galaxy Zoo 101 percentage complete,Hubble\'s Law percentage complete\n';
 
     this.props.selectedClassroom.students.map((student) => {
       let studentName = (student.zooniverseDisplayName && student.zooniverseDisplayName.length > 0)
@@ -97,13 +97,13 @@ export class ClassroomEditorContainer extends React.Component {
       const studentGalaxyCount = galaxyStudentData[0].attributes.classifications_count;
       const studentHubbleCount = hubbleStudentData[0].attributes.classifications_count;
       const galaxyCountStat = `${studentGalaxyCount}/${galaxyClassificationTarget}`;
-      const hubbleCountStat = `${studentHubbleCount}/${hubbleClassificationTarget}`
+      const hubbleCountStat = `${studentHubbleCount}/${hubbleClassificationTarget}`;
       const galaxyPercentageStat = (studentGalaxyCount / (+galaxyClassificationTarget)) * 100;
       const hubblePercentageStat = (studentHubbleCount / (+hubbleClassificationTarget)) * 100;
       const row = `"${classroomName}","${studentName}",${galaxyCountStat},${hubbleCountStat},${galaxyPercentageStat},${hubblePercentageStat}\n`;
-      exampleData += row;
+      csvData += row;
     });
-    saveAs(blobbifyData(exampleData, this.props.contentType), generateFilename('astro-', '.csv'));
+    saveAs(blobbifyData(csvData, this.props.contentType), generateFilename('astro101-', '.csv'));
   }
 
   maybeRemoveStudentFromClassroom(classroomId, studentId) {


### PR DESCRIPTION
To be merged after #90. This closes #50. It finishes the export stats class method for the individual classroom edit view. Note: I've renamed the button and method to `Export Stats` and `exportStats` because I think we should avoid saying grades anywhere. As a former IT person who worked for a couple of Universities, even implying we store grades could make us vulnerable to complying with student privacy laws. It's up to the teacher if they want to use these stats in their grading, but they aren't grades. 