### PR TITLE
Update caesar requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8667,6 +8667,11 @@
         "sugar-client": "1.0.1"
       }
     },
+    "papaparse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.3.6.tgz",
+      "integrity": "sha1-lWbtoOyrE6/LdApiOBxpn0hssUU="
+    },
     "param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jumpstate": "^2.2.2",
     "leaflet": "1.2.0",
     "panoptes-client": "~2.7.2",
+    "papaparse": "~4.3.6",
     "prop-types": "~15.5.10",
     "query-string": "~5.0.0",
     "react": "~15.6.1",

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -33,7 +33,11 @@ function AstroClassroomsTable(props) {
   const assignmentsMetadata = (props.selectedProgram && props.selectedProgram.metadata) ? props.selectedProgram.metadata.assignments : '';
   return (
     <Box>
-      <ExportModal onClose={props.onExportModalClose} assignment={props.assignmentToExport} />
+      <ExportModal
+        assignment={props.assignmentToExport}
+        onClose={props.onExportModalClose}
+        requestNewExport={props.requestNewExport}
+      />
       {props.children}
       <Table className="manager-table">
         <thead className="manager-table__headers">

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -35,6 +35,7 @@ function AstroClassroomsTable(props) {
     <Box>
       <ExportModal
         assignment={props.assignmentToExport}
+        getCsvFile={props.getCsvFile}
         onClose={props.onExportModalClose}
         requestNewExport={props.requestNewExport}
       />
@@ -151,6 +152,7 @@ function AstroClassroomsTable(props) {
 AstroClassroomsTable.defaultProps = {
   assignmentToExport: {},
   closeConfirmationDialog: () => {},
+  getCsvFile: () => {},
   maybeDeleteClassroom: () => {},
   selectClassroom: () => {},
   showExportModal: () => {},
@@ -161,6 +163,7 @@ AstroClassroomsTable.defaultProps = {
 AstroClassroomsTable.propTypes = {
   assignmentToExport: PropTypes.object,
   closeConfirmationDialog: PropTypes.func,
+  getCsvFile: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
   selectClassroom: PropTypes.func,
   showExportModal: PropTypes.func,

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -152,10 +152,10 @@ function AstroClassroomsTable(props) {
 AstroClassroomsTable.defaultProps = {
   assignmentToExport: {},
   closeConfirmationDialog: () => {},
-  getCsvFile: () => {},
   maybeDeleteClassroom: () => {},
   selectClassroom: () => {},
   showExportModal: () => {},
+  transformData: () => {},
   ...CLASSROOMS_INITIAL_STATE,
   ...ASSIGNMENTS_INITIAL_STATE
 };
@@ -163,10 +163,10 @@ AstroClassroomsTable.defaultProps = {
 AstroClassroomsTable.propTypes = {
   assignmentToExport: PropTypes.object,
   closeConfirmationDialog: PropTypes.func,
-  getCsvFile: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
   selectClassroom: PropTypes.func,
   showExportModal: PropTypes.func,
+  transformData: PropTypes.func,
   ...CLASSROOMS_PROPTYPES,
   ...ASSIGNMENTS_PROPTYPES
 };

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -35,7 +35,7 @@ function AstroClassroomsTable(props) {
     <Box>
       <ExportModal
         assignment={props.assignmentToExport}
-        getCsvFile={props.getCsvFile}
+        transformData={props.transformData}
         onClose={props.onExportModalClose}
         requestNewExport={props.requestNewExport}
       />

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -53,7 +53,7 @@ const ExportModal = ({ caesarExport, caesarExports, caesarExportStatus, onClose,
           {pending &&
             <Paragraph>
               <Status value="warning" />{' '}
-              Export request is processing.
+              Export request is processing. Please check again later.
             </Paragraph>}
           {noExport &&
             <Paragraph>
@@ -62,10 +62,15 @@ const ExportModal = ({ caesarExport, caesarExports, caesarExportStatus, onClose,
             </Paragraph>}
           {caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport &&
             caesarExportStatus === CAESAR_EXPORTS_STATUS.ERROR &&
-            <Paragraph>
-              <Status value="critical" />{' '}
-              Something went wrong
-            </Paragraph>}
+            <Box>
+              <Paragraph>
+                <Status value="critical" />{' '}
+                Something went wrong. Either the export processing failed or the server is not available. Please try again.
+              </Paragraph>
+              <Paragraph>
+                <Button secondary={true} fill={false} onClick={requestNewExport} label="Request new export" />
+              </Paragraph>
+            </Box>}
           <Box direction="row">
             <SuperDownloadButton
               className="export-modal__button"
@@ -77,6 +82,7 @@ const ExportModal = ({ caesarExport, caesarExports, caesarExportStatus, onClose,
             />
             <GoogleDriveExportButton
               className="export-modal__button"
+              disabled={disableButton}
             />
           </Box>
         </Box>
@@ -99,7 +105,6 @@ ExportModal.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    caesarExports: state.caesarExports.caesarExports,
     caesarExport: state.caesarExports.caesarExport,
     caesarExportStatus: state.caesarExports.status,
     requestedExports: state.caesarExports.requestedExports,

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -18,7 +18,7 @@ import {
 } from '../../ducks/caesar-exports';
 
 
-const ExportModal = ({ caesarExport, caesarExports, caesarExportStatus, onClose, requestedExports, requestNewExport, showModal }) => {
+function ExportModal({ caesarExport, caesarExports, caesarExportStatus, getCsvFile, onClose, requestedExports, requestNewExport, showModal }) {
   // TODO add url prop to SuperDownloadButton
   // TODO disable Export to Google Sheets button like the download button.
   // It's not disabled for testing purposes at the moment
@@ -78,6 +78,7 @@ const ExportModal = ({ caesarExport, caesarExports, caesarExportStatus, onClose,
               fileNameBase="astro101-"
               primary={true}
               text="Download CSV"
+              transformData={getCsvFile}
               url={caesarExport.url}
             />
             <GoogleDriveExportButton

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -18,7 +18,7 @@ import {
 } from '../../ducks/caesar-exports';
 
 
-function ExportModal({ caesarExport, caesarExports, caesarExportStatus, getCsvFile, onClose, requestedExports, requestNewExport, showModal }) {
+function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose, requestedExports, requestNewExport, showModal, transformData }) {
   // TODO add url prop to SuperDownloadButton
   // TODO disable Export to Google Sheets button like the download button.
   // It's not disabled for testing purposes at the moment
@@ -78,7 +78,7 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, getCsvFi
               fileNameBase="astro101-"
               primary={true}
               text="Download CSV"
-              transformData={getCsvFile}
+              transformData={transformData}
               url={caesarExport.url}
             />
             <GoogleDriveExportButton

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -19,30 +19,35 @@ import {
 } from '../../ducks/caesar-exports';
 
 
-const ExportModal = ({ caesarExport, caesarExportStatus, onClose, showModal }) => {
+const ExportModal = ({ caesarExport, caesarExportStatus, onClose, requestedExports, showModal }) => {
   // TODO replace Date.now() with timestamp in export response
   // TODO add url prop to SuperDownloadButton
   // TODO disable Export to Google Sheets button like the download button.
   // It's not disabled for testing purposes at the moment
   const noExport = caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport &&
     caesarExportStatus === CAESAR_EXPORTS_STATUS.SUCCESS;
-
-  const disableButton = noExport || (caesarExportStatus === CAESAR_EXPORTS_STATUS.FETCHING && caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport);
+  const fetching = caesarExportStatus === CAESAR_EXPORTS_STATUS.FETCHING && caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport;
+  const pending = Object.keys(requestedExports).length > 0 && caesarExportStatus === CAESAR_EXPORTS_STATUS.PENDING;
+  const disableButton = noExport || fetching || pending;
 
   if (showModal) {
     return (
       <Layer className="export-modal" closer={true} onClose={onClose}>
         <Box pad="medium" justify="between">
           <Heading tag="h2">Data Export</Heading>
-          {caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport &&
-            caesarExportStatus === CAESAR_EXPORTS_STATUS.FETCHING &&
+          {fetching &&
             <Paragraph align="center"><Spinning /></Paragraph>}
-          {Object.keys(caesarExport) > 0 &&
+          {Object.keys(caesarExport).length > 0 &&
             caesarExportStatus === CAESAR_EXPORTS_STATUS.SUCCESS &&
             <Paragraph>
               <Status value="ok" />{' '}
               Export available since{' '}
               <TimeStamp value={Date.now()} />
+            </Paragraph>}
+          {pending &&
+            <Paragraph>
+              <Status value="warning" />{' '}
+              Export request is processing.
             </Paragraph>}
           {noExport &&
             <Paragraph>
@@ -87,6 +92,7 @@ function mapStateToProps(state) {
   return {
     caesarExport: state.caesarExports.caesarExport,
     caesarExportStatus: state.caesarExports.status,
+    requestedExports: state.caesarExports.requestedExports,
     showModal: state.caesarExports.showModal
   };
 }

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -182,10 +182,10 @@ const ClassroomEditor = (props) => {
             props.assignments[props.selectedClassroom.id] &&
             props.assignments[props.selectedClassroom.id].length > 0 &&
               students.map((student) => {
-                const galaxyAssignment = assignments.filter(
-                  assignment => assignment.name === i2aAssignmentNames.first);
-                const hubbleAssignment = assignments.filter(
-                  assignment => assignment.name === i2aAssignmentNames.second);
+                const galaxyAssignment = props.assignments[props.selectedClassroom.id].filter(
+                  assignment => assignment.name === i2aAssignmentNames.galaxy);
+                const hubbleAssignment = props.assignments[props.selectedClassroom.id].filter(
+                  assignment => assignment.name === i2aAssignmentNames.hubble);
 
                 // Why are the ids in the student_user_id property numbers?!?!?!
                 const galaxyStudentData = galaxyAssignment[0].studentAssignmentsData.filter(

--- a/src/components/common/SuperDownloadButton.jsx
+++ b/src/components/common/SuperDownloadButton.jsx
@@ -61,21 +61,7 @@ class SuperDownloadButton extends React.Component {
 
   handleClick() {
     if (this.props.transformData && typeof this.props.transformData === 'function') {
-      const transformedData = Papa.parse(this.props.url, { complete: this.props.transformData, download: true });
-      console.log('transformedData', transformedData);
-      // return
-      //   .then((newCsvData) => {
-      //     console.log('then of transformData')
-      //     if (newCsvData) {
-      //       console.log('newCsvData', newCsvData)
-      //       saveAs(blobbifyData(newCsvData, this.props.contentType), generateFilename('astro101-', '.csv'));
-      //     }
-      //   })
-      //   .catch((error) => {
-      //     console.error('ERROR (SuperDownloadButton): data transformation error', error);
-      //     this.setState({ status: STATUS.ERROR });
-      //   });
-      return null;
+      return Papa.parse(this.props.url, { complete: this.props.transformData, download: true });
     }
 
     return this.download();

--- a/src/components/common/SuperDownloadButton.jsx
+++ b/src/components/common/SuperDownloadButton.jsx
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
 
 import { saveAs } from 'browser-filesaver';
 import superagent from 'superagent';
+import Papa from 'papaparse';
 
 import Button from 'grommet/components/Button';
 import Toast from 'grommet/components/Toast';
@@ -59,20 +60,22 @@ class SuperDownloadButton extends React.Component {
   }
 
   handleClick() {
-    console.log('handleClick')
     if (this.props.transformData && typeof this.props.transformData === 'function') {
-      console.log('transformData defined')
-      return this.props.transformData()
-        .then((newCsvData) => {
-          if (newCsvData) {
-            console.log('newCsvData', newCsvData)
-            saveAs(blobbifyData(newCsvData, this.props.contentType), generateFilename('astro101-', '.csv'));
-          }
-        })
-        .catch((error) => {
-          console.error('ERROR (SuperDownloadButton): data transformation error', error);
-          this.setState({ status: STATUS.ERROR });
-        });
+      const transformedData = Papa.parse(this.props.url, { complete: this.props.transformData, download: true });
+      console.log('transformedData', transformedData);
+      // return
+      //   .then((newCsvData) => {
+      //     console.log('then of transformData')
+      //     if (newCsvData) {
+      //       console.log('newCsvData', newCsvData)
+      //       saveAs(blobbifyData(newCsvData, this.props.contentType), generateFilename('astro101-', '.csv'));
+      //     }
+      //   })
+      //   .catch((error) => {
+      //     console.error('ERROR (SuperDownloadButton): data transformation error', error);
+      //     this.setState({ status: STATUS.ERROR });
+      //   });
+      return null;
     }
 
     return this.download();

--- a/src/components/common/SuperDownloadButton.jsx
+++ b/src/components/common/SuperDownloadButton.jsx
@@ -48,6 +48,7 @@ class SuperDownloadButton extends React.Component {
   constructor(props) {
     super(props);
     this.download = this.download.bind(this);
+    this.handleClick = this.handleClick.bind(this);
 
     this.altForm = null;
     this.altFormData = null;
@@ -55,6 +56,26 @@ class SuperDownloadButton extends React.Component {
     this.state = {  // Keep the state simple and local; no need for Redux connections.
       status: STATUS.IDLE
     };
+  }
+
+  handleClick() {
+    console.log('handleClick')
+    if (this.props.transformData && typeof this.props.transformData === 'function') {
+      console.log('transformData defined')
+      return this.props.transformData()
+        .then((newCsvData) => {
+          if (newCsvData) {
+            console.log('newCsvData', newCsvData)
+            saveAs(blobbifyData(newCsvData, this.props.contentType), generateFilename('astro101-', '.csv'));
+          }
+        })
+        .catch((error) => {
+          console.error('ERROR (SuperDownloadButton): data transformation error', error);
+          this.setState({ status: STATUS.ERROR });
+        });
+    }
+
+    return this.download();
   }
 
   download() {
@@ -98,7 +119,7 @@ class SuperDownloadButton extends React.Component {
     return (
       <Button
         className={this.props.className ? this.props.className : null}
-        onClick={this.props.disabled ? null : this.download}
+        onClick={this.props.disabled ? null : this.handleClick}
         icon={(this.state.status === STATUS.FETCHING) ? <SpinningIcon size="small" /> : this.props.icon}
         primary={this.props.primary}
         label={this.props.text}
@@ -135,6 +156,10 @@ SuperDownloadButton.propTypes = {
   icon: PropTypes.node,
   primary: PropTypes.bool,
   text: PropTypes.string,
+  transformData: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object
+  ]),
   url: PropTypes.string,
   useZooniversalTranslator: PropTypes.bool
 };
@@ -147,6 +172,7 @@ SuperDownloadButton.defaultProps = {
   icon: <DownloadIcon size="small" />,
   primary: false,
   text: ZooTran('Download'),
+  transformData: null,
   url: '',
   useZooniversalTranslator: true
 };

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -45,19 +45,16 @@ class AstroClassroomsTableContainer extends React.Component {
         !this.props.requestNewExport[classroom.id] &&
         localStorageExport[classroom.id] &&
         localStorageExport[classroom.id].workflow_id.toString() === assignment.workflowId) {
-      console.log('pendingExport in localStorage')
       this.checkPendingExport(assignment, classroom, localStorageExport[classroom.id].id);
     }
 
     if (Object.keys(this.props.requestedExports).length > 0 &&
         this.props.requestedExports[classroom.id] &&
         this.props.requestedExports[classroom.id].workflow_id.toString() === assignment.workflowId) {
-      console.log('pendingExport in component state')
       this.checkPendingExport(assignment, classroom, this.props.requestedExports[classroom.id].id);
     }
 
     if (Object.keys(this.props.requestedExports).length === 0 && !localStorageExport) {
-      console.log('no requestedExports')
       this.checkExportExistence(assignment, classroom)
         .then((caesarExports) => {
           if (caesarExports && caesarExports.length === 0) {
@@ -88,10 +85,8 @@ class AstroClassroomsTableContainer extends React.Component {
 
   transformData(csvData) {
     if (this.state.toExport.assignment.name === i2aAssignmentNames.galaxy) {
-      console.log('galaxy assignment')
-      return this.transformGalaxyDataCsv(csvData);
+      Promise.resolve(this.transformGalaxyDataCsv(csvData));
     } else if (this.state.toExport.assignment.name === i2aAssignmentNames.hubble) {
-      console.log('hubble assignment')
       Promise.resolve(this.transformHubbleDataCsv(csvData))
         .then((transformedData) => {
           const filename = generateFilename('astro101-');
@@ -103,7 +98,7 @@ class AstroClassroomsTableContainer extends React.Component {
   }
 
   transformGalaxyDataCsv(csvData) {
-    console.log(csvData);
+    console.log('TO DO: transform data for galaxy activity', csvData);
   }
 
   transformHubbleDataCsv(csvData) {

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -27,7 +27,13 @@ class AstroClassroomsTableContainer extends React.Component {
     this.setState({ toExport: { assignment, classroom } });
 
     Actions.caesarExports.showModal();
-    Actions.getCaesarExport({ assignment, classroom });
+    Actions.getCaesarExport({ assignment, classroom })
+      .then((response) => {
+        if (response.status === 404) {
+          Actions.createCaesarExport({ assignment, classroom });
+        }
+        console.log('response in then', response.status);
+      });
   }
 
   render() {

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Actions } from 'jumpstate';
 import { connect } from 'react-redux';
+import Papa from 'papaparse';
 import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
 
 import {
   CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
 } from '../../ducks/caesar-exports';
+import { i2aAssignmentNames } from '../../ducks/programs';
 
 class AstroClassroomsTableContainer extends React.Component {
   constructor() {
@@ -18,9 +20,11 @@ class AstroClassroomsTableContainer extends React.Component {
       }
     };
 
-    this.onExportModalClose = this.onExportModalClose.bind(this);
+    this.getCsvFile = this.getCsvFile.bind(this);
     this.handleRequestForNewExport = this.handleRequestForNewExport.bind(this);
+    this.onExportModalClose = this.onExportModalClose.bind(this);
     this.showExportModal = this.showExportModal.bind(this);
+    this.transformData = this.transformData.bind(this);
   }
 
   onExportModalClose() {
@@ -81,6 +85,34 @@ class AstroClassroomsTableContainer extends React.Component {
     Actions.createCaesarExport({ assignment, classroom });
   }
 
+  getCsvFile() {
+    console.log('getCsvFile called')
+    if (Object.keys(this.props.caesarExport).length === 0) return Promise.resolve(null);
+
+    return Promise.resolve(Papa.parse(this.props.caesarExport.url, { complete: this.transformData, download: true }));
+    // return Promise.resolve(this.transformData(data));
+  }
+
+  transformData(csvData) {
+    if (this.state.toExport.assignment.name === i2aAssignmentNames.galaxy) {
+      console.log('galaxy assignment')
+      return this.transformGalaxyDataCsv(csvData);
+    } else if (this.state.toExport.assignment.name === i2aAssignmentNames.hubble) {
+      console.log('hubble assignment')
+      return this.transformHubbleDataCsv(csvData);
+    }
+
+    return null;
+  }
+
+  transformGalaxyDataCsv(csvData) {
+    console.log(csvData);
+  }
+
+  transformHubbleDataCsv(csvData) {
+    console.log(csvData);
+  }
+
   render() {
     return (
       <AstroClassroomsTable
@@ -89,6 +121,7 @@ class AstroClassroomsTableContainer extends React.Component {
         onExportModalClose={this.onExportModalClose}
         requestNewExport={this.handleRequestForNewExport}
         showExportModal={this.showExportModal}
+        getCsvFile={this.getCsvFile}
       >
         {this.props.children}
       </AstroClassroomsTable>
@@ -105,7 +138,10 @@ AstroClassroomsTableContainer.propTypes = {
 };
 
 function mapStateToProps(state) {
-  return { requestedExports: state.caesarExports.requestedExports };
+  return {
+    caesarExport: state.caesarExports.caesarExport,
+    requestedExports: state.caesarExports.requestedExports
+  };
 }
 
 export default connect(mapStateToProps)(AstroClassroomsTableContainer);

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -29,10 +29,9 @@ class AstroClassroomsTableContainer extends React.Component {
     Actions.caesarExports.showModal();
     Actions.getCaesarExport({ assignment, classroom })
       .then((response) => {
-        if (response.status === 404) {
+        if (response.status === 404 || response.length === 0) {
           Actions.createCaesarExport({ assignment, classroom });
         }
-        console.log('response in then', response.status);
       });
   }
 

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -3,6 +3,10 @@ import { Actions } from 'jumpstate';
 import { connect } from 'react-redux';
 import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
 
+import {
+  CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
+} from '../../ducks/caesar-exports';
+
 class AstroClassroomsTableContainer extends React.Component {
   constructor() {
     super();
@@ -36,29 +40,26 @@ class AstroClassroomsTableContainer extends React.Component {
     }
 
     if (Object.keys(this.props.requestedExports).length === 0) {
-
       this.checkExportExistence(assignment, classroom)
-      // this.requestNewExport(assignment, classroom);
+        .then((caesarExports) => {
+          if (caesarExports && caesarExports.length === 0) {
+            this.requestNewExport(assignment, classroom);
+          }
+        });
     }
   }
 
   checkExportExistence(assignment, classroom) {
-    return Actions.getCaesarExports({ assignment, classroom })
-      .then((caesarExports) => {
-        console.log('caesarExports', caesarExports)
-      })
+    return Actions.getCaesarExports({ assignment, classroom });
   }
 
   checkPendingExport(assignment, classroom) {
     const exportId = this.props.requestedExports[classroom.id].id;
 
-    return Actions.getCaesarExport({ assignment, classroom, id: exportId })
-      .then((caesarExport) => {
-        console.log('export', caesarExport)
-      })
+    return Actions.getCaesarExport({ assignment, classroom, id: exportId });
   }
 
-  requestNewExport(assignment, classroom) {
+  requestNewExport(assignment = this.state.assignment, classroom = this.state.classroom) {
     return Actions.createCaesarExport({ assignment, classroom });
   }
 
@@ -68,6 +69,7 @@ class AstroClassroomsTableContainer extends React.Component {
         {...this.props}
         assignmentToExport={this.state.toExport.assignment}
         onExportModalClose={this.onExportModalClose}
+        requestNewExport={this.requestNewExport}
         showExportModal={this.showExportModal}
       >
         {this.props.children}
@@ -75,6 +77,14 @@ class AstroClassroomsTableContainer extends React.Component {
     );
   }
 }
+
+AstroClassroomsTableContainer.defaultProps = {
+  ...CAESAR_EXPORTS_INITIAL_STATE
+};
+
+AstroClassroomsTableContainer.propTypes = {
+  ...CAESAR_EXPORTS_PROPTYPES
+};
 
 function mapStateToProps(state) {
   return { requestedExports: state.caesarExports.requestedExports };

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -36,17 +36,9 @@ class AstroClassroomsTableContainer extends React.Component {
   }
 
   showExportModal(assignment, classroom) {
-    const localStorageExport = JSON.parse(localStorage.getItem('pendingExport'));
     this.setState({ toExport: { assignment, classroom } });
 
     Actions.caesarExports.showModal();
-
-    if (localStorageExport &&
-        !this.props.requestNewExport[classroom.id] &&
-        localStorageExport[classroom.id] &&
-        localStorageExport[classroom.id].workflow_id.toString() === assignment.workflowId) {
-      this.checkPendingExport(assignment, classroom, localStorageExport[classroom.id].id);
-    }
 
     if (Object.keys(this.props.requestedExports).length > 0 &&
         this.props.requestedExports[classroom.id] &&
@@ -54,7 +46,7 @@ class AstroClassroomsTableContainer extends React.Component {
       this.checkPendingExport(assignment, classroom, this.props.requestedExports[classroom.id].id);
     }
 
-    if (Object.keys(this.props.requestedExports).length === 0 && !localStorageExport) {
+    if (Object.keys(this.props.requestedExports).length === 0) {
       this.checkExportExistence(assignment, classroom)
         .then((caesarExports) => {
           if (caesarExports && caesarExports.length === 0) {

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -103,7 +103,7 @@ export class ClassroomEditorContainer extends React.Component {
       const row = `"${classroomName}","${studentName}",${galaxyCountStat},${hubbleCountStat},${galaxyPercentageStat},${hubblePercentageStat}\n`;
       csvData += row;
     });
-    saveAs(blobbifyData(csvData, this.props.contentType), generateFilename('astro101-', '.csv'));
+    saveAs(blobbifyData(csvData, 'text/csv'), generateFilename('astro101-', '.csv'));
   }
 
   maybeRemoveStudentFromClassroom(classroomId, studentId) {

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -61,8 +61,8 @@ function handleError(error) {
 }
 
 function sortAssignments(assignments) {
-  const firstAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.first);
-  const secondAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.second);
+  const firstAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.galaxy);
+  const secondAssignment = assignments.find(assignment => assignment.name === i2aAssignmentNames.hubble);
 
   if (firstAssignment && secondAssignment) {
     return [firstAssignment, secondAssignment];

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -57,13 +57,36 @@ const showModal = (state) => {
 
 // Effects are for async actions and get automatically to the global Actions list
 // Requests to caesar should include an Accept: 'application/json' header
+Effect('getCaesarExports', (data) => {
+  Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
+  const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/`;
+
+  return superagent.get(requestUrl)
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/json')
+    .set('Authorization', apiClient.headers.Authorization)
+    .query({ requested_data: 'reductions' })
+    .then((response) => {
+      console.log('response', response.status);
+      if (!response) { throw 'ERROR (ducks/caesarExports/getCaesarExport): No response'; }
+      if (response.ok) {
+        console.log('its ok');
+      }
+
+      return response.body;
+      Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
+    }).catch((error) => {
+      if (error.status !== 404) handleError(error);
+      if (error.status === 404) {
+        Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
+        return error;
+      }
+    });
+});
+
 Effect('getCaesarExport', (data) => {
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
-  let requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/`;
-
-  if (data.id) {
-    requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/${data.id}`;
-  }
+  const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/${data.id}`;
 
   return superagent.get(requestUrl)
     .set('Accept', 'application/json')

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -56,6 +56,7 @@ const showModal = (state) => {
 };
 
 // Effects are for async actions and get automatically to the global Actions list
+// Requests to caesar should include an Accept: 'application/json' header
 Effect('getCaesarExport', (data) => {
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
   let requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/`;
@@ -74,7 +75,7 @@ Effect('getCaesarExport', (data) => {
     })
     .then((response) => {
       console.log('response', response.status);
-      if (!response) { throw 'ERROR (ducks/caesarExports/getCaesarExport): No response'; };
+      if (!response) { throw 'ERROR (ducks/caesarExports/getCaesarExport): No response'; }
       if (response.ok) {
         console.log('its ok');
       }
@@ -94,6 +95,7 @@ Effect('createCaesarExport', (data) => {
   const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/`;
 
   return superagent.post(requestUrl)
+    .set('Accept', 'application/json')
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
     .query({

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -57,8 +57,9 @@ const showModal = (state) => {
 
 // Effects are for async actions and get automatically to the global Actions list
 Effect('getCaesarExport', (data) => {
-  let requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/new`;
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
+  let requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/`;
+
   if (data.id) {
     requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/${data.id}`;
   }
@@ -71,10 +72,37 @@ Effect('getCaesarExport', (data) => {
       subgroup: data.classroom.zooniverseGroupId
     })
     .then((response) => {
-      console.log('response', response.status)
+      console.log('response', response.status);
       if (!response) { throw 'ERROR (ducks/caesarExports/getCaesarExport): No response'; };
       if (response.ok) {
-        console.log('its ok')
+        console.log('its ok');
+      }
+
+      Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
+    }).catch((error) => {
+      if (error.status !== 404) handleError(error);
+      if (error.status === 404) {
+        Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
+        return error;
+      }
+    });
+});
+
+Effect('createCaesarExport', (data) => {
+  const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/`;
+
+  return superagent.post(requestUrl)
+    .set('Content-Type', 'application/json')
+    .set('Authorization', apiClient.headers.Authorization)
+    .query({
+      requested_data: 'reductions',
+      subgroup: data.classroom.zooniverseGroupId
+    })
+    .then((response) => {
+      console.log('response', response.status);
+      if (!response) { throw 'ERROR (ducks/caesarExports/getCaesarExport): No response'; }
+      if (response.ok) {
+        console.log('its ok');
       }
 
       Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -65,6 +65,7 @@ Effect('getCaesarExport', (data) => {
   }
 
   return superagent.get(requestUrl)
+    .set('Accept', 'application/json')
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
     .query({
@@ -78,6 +79,7 @@ Effect('getCaesarExport', (data) => {
         console.log('its ok');
       }
 
+      return response.body;
       Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
     }).catch((error) => {
       if (error.status !== 404) handleError(error);

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -125,8 +125,6 @@ Effect('getCaesarExports', (data) => {
 });
 
 Effect('getCaesarExport', (data) => {
-  if (localStorage.getItem('pendingExport')) localStorage.removeItem('pendingExport');
-
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
   const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/${data.id}`;
 
@@ -149,7 +147,6 @@ Effect('getCaesarExport', (data) => {
         if (responseData.status === 'pending') {
           Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.PENDING);
           const requestedExport = { [data.classroom.id]: responseData };
-          localStorage.setItem('pendingExport', JSON.stringify(requestedExport));
           Actions.caesarExports.setRequestedExports(requestedExport);
         }
 

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -141,6 +141,8 @@ Effect('getCaesarExport', (data) => {
         if (responseData.status === 'complete') {
           Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
           Actions.caesarExports.setCaesarExport(responseData);
+          Actions.caesarExports.setRequestedExports(CAESAR_EXPORTS_INITIAL_STATE.requestedExport);
+
           return response.body;
         }
 

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import { get, post, put, httpDelete } from '../lib/edu-api';
 import { env } from '../lib/config';
 
-// testing mocks
+// testing mocks and constants
 export const i2aAssignmentNames = {
-  first: "Galaxy Zoo 101",
-  second: "Hubble's Law"
+  galaxy: "Galaxy Zoo 101",
+  hubble: "Hubble's Law"
 }
 
 const i2a = {
@@ -30,12 +30,12 @@ const i2a = {
         // These are just test projects on staging...
         // classifications_target should be a string?
         "2218": {
-          name: i2aAssignmentNames.second,
+          name: i2aAssignmentNames.hubble,
           classifications_target: "10",
           slug: 'srallen086/intro2astro-hubble-testing'
         },
         "3037": {
-          name: i2aAssignmentNames.first,
+          name: i2aAssignmentNames.galaxy,
           classifications_target: "22",
           slug: 'srallen086/galaxy-zoo-in-astronomy-101'
         }
@@ -59,12 +59,12 @@ const i2a = {
         // to then build the URL to the project in the UI.
         // TODO: replace the workflow ids here with the production ids
         "1315": {
-          name: i2aAssignmentNames.second,
+          name: i2aAssignmentNames.hubble,
           classifications_target: "10",
           slug: 'srallen086/intro2astro-hubble-testing'
         },
         "1771": {
-          name: i2aAssignmentNames.first,
+          name: i2aAssignmentNames.galaxy,
           classifications_target: "22",
           slug: 'srallen086/galaxy-zoo-in-astronomy-101'
         }


### PR DESCRIPTION
For #26, this is a step forward in getting the caesar requests to work. The 404 we saw before was a red herring. It didn't actually work, for one, because the reduction type data export wasn't available publicly before. This is now fixed and Intro2Astro workflows have public caesar exports.

This PR fixes the POST to create the export, stores the pending export in the redux store and if requested again, checks against the presence of a pending export. If there is a pending export, we request using its id. 

There are a few issues still needing resolving, such as, how do we best check for a pre-existing export so we don't unnecessarily create new exports. Because of the remaining API/UX questions, there are still a few logs and commented out items. 