### PR TITLE
Finished google export function

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -34,7 +34,7 @@ function AstroClassroomsTable(props) {
   return (
     <Box>
       <ExportModal
-        assignment={props.assignmentToExport}
+        toExport={props.toExport}
         transformData={props.transformData}
         onClose={props.onExportModalClose}
         requestNewExport={props.requestNewExport}
@@ -150,22 +150,25 @@ function AstroClassroomsTable(props) {
 };
 
 AstroClassroomsTable.defaultProps = {
-  assignmentToExport: {},
   closeConfirmationDialog: () => {},
   maybeDeleteClassroom: () => {},
   selectClassroom: () => {},
   showExportModal: () => {},
+  toExport: {},
   transformData: () => {},
   ...CLASSROOMS_INITIAL_STATE,
   ...ASSIGNMENTS_INITIAL_STATE
 };
 
 AstroClassroomsTable.propTypes = {
-  assignmentToExport: PropTypes.object,
   closeConfirmationDialog: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
   selectClassroom: PropTypes.func,
   showExportModal: PropTypes.func,
+  toExport: PropTypes.shape({
+    assignment: PropTypes.object,
+    classroom: PropTypes.object
+  }),
   transformData: PropTypes.func,
   ...CLASSROOMS_PROPTYPES,
   ...ASSIGNMENTS_PROPTYPES

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -152,7 +152,6 @@ function AstroClassroomsTable(props) {
 AstroClassroomsTable.defaultProps = {
   assignmentToExport: {},
   closeConfirmationDialog: () => {},
-  getCsvFile: () => {},
   maybeDeleteClassroom: () => {},
   selectClassroom: () => {},
   showExportModal: () => {},
@@ -164,7 +163,6 @@ AstroClassroomsTable.defaultProps = {
 AstroClassroomsTable.propTypes = {
   assignmentToExport: PropTypes.object,
   closeConfirmationDialog: PropTypes.func,
-  getCsvFile: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
   selectClassroom: PropTypes.func,
   showExportModal: PropTypes.func,

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -152,6 +152,7 @@ function AstroClassroomsTable(props) {
 AstroClassroomsTable.defaultProps = {
   assignmentToExport: {},
   closeConfirmationDialog: () => {},
+  getCsvFile: () => {},
   maybeDeleteClassroom: () => {},
   selectClassroom: () => {},
   showExportModal: () => {},
@@ -163,6 +164,7 @@ AstroClassroomsTable.defaultProps = {
 AstroClassroomsTable.propTypes = {
   assignmentToExport: PropTypes.object,
   closeConfirmationDialog: PropTypes.func,
+  getCsvFile: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
   selectClassroom: PropTypes.func,
   showExportModal: PropTypes.func,

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -55,6 +55,11 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose,
               <Status value="warning" />{' '}
               Export request is processing. Please check again later.
             </Paragraph>}
+          {pending &&
+            <Paragraph>
+              <Status value="warning" />{' '}
+              Export request is processing.
+            </Paragraph>}
           {noExport &&
             <Paragraph>
               <Status value="warning" />{' '}

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -41,7 +41,12 @@ function ExportModal({
   const fetching = caesarExportStatus === CAESAR_EXPORTS_STATUS.FETCHING &&
     (caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport ||
     caesarExports === CAESAR_EXPORTS_INITIAL_STATE.caesarExports);
-  const pending = Object.keys(requestedExports).length > 0 && caesarExportStatus === CAESAR_EXPORTS_STATUS.PENDING;
+  const pending = Object.keys(requestedExports).length > 0 &&
+    caesarExportStatus === CAESAR_EXPORTS_STATUS.PENDING &&
+    toExport.classroom &&
+    toExport.assignment &&
+    requestedExports[toExport.classroom.id] &&
+    requestedExports[toExport.classroom.id].workflow_id.toString() === toExport.assignment.workflowId;
   const disableButton = noExport || fetching || pending;
   const success = Object.keys(caesarExport).length > 0 && caesarExportStatus === CAESAR_EXPORTS_STATUS.SUCCESS;
   const assignmentName = (toExport.assignment && toExport.assignment.name) ? prepStringForFilename(toExport.assignment.name) : null;

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -111,6 +111,7 @@ ExportModal.propTypes = {
 
 function mapStateToProps(state) {
   return {
+    caesarExports: state.caesarExports.caesarExports,
     caesarExport: state.caesarExports.caesarExport,
     caesarExportStatus: state.caesarExports.status,
     requestedExports: state.caesarExports.requestedExports,

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -55,11 +55,6 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose,
               <Status value="warning" />{' '}
               Export request is processing. Please check again later.
             </Paragraph>}
-          {pending &&
-            <Paragraph>
-              <Status value="warning" />{' '}
-              Export request is processing.
-            </Paragraph>}
           {noExport &&
             <Paragraph>
               <Status value="warning" />{' '}
@@ -111,7 +106,6 @@ ExportModal.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    caesarExports: state.caesarExports.caesarExports,
     caesarExport: state.caesarExports.caesarExport,
     caesarExportStatus: state.caesarExports.status,
     requestedExports: state.caesarExports.requestedExports,

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
 import Heading from 'grommet/components/Heading';
@@ -10,6 +11,7 @@ import Timestamp from 'grommet/components/Timestamp';
 import Paragraph from 'grommet/components/Paragraph';
 import Layer from 'grommet/components/Layer';
 import Button from 'grommet/components/Button';
+import Anchor from 'grommet/components/Anchor';
 
 import SuperDownloadButton from '../common/SuperDownloadButton';
 import GoogleDriveExportButton from './GoogleDriveExportButton';
@@ -18,10 +20,21 @@ import {
 } from '../../ducks/caesar-exports';
 
 
-function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose, requestedExports, requestNewExport, showModal, transformData }) {
-  // TODO add url prop to SuperDownloadButton
-  // TODO disable Export to Google Sheets button like the download button.
-  // It's not disabled for testing purposes at the moment
+function prepStringForFilename(string) {
+  return string.replace(/\s+/g, '-').toLowerCase();
+}
+
+function ExportModal({
+  caesarExport,
+  caesarExports,
+  caesarExportStatus,
+  googleFileUrl,
+  onClose,
+  requestedExports,
+  requestNewExport,
+  showModal,
+  toExport,
+  transformData }) {
   const noExport = caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport &&
     caesarExports === CAESAR_EXPORTS_INITIAL_STATE.caesarExports &&
     caesarExportStatus === CAESAR_EXPORTS_STATUS.SUCCESS;
@@ -31,6 +44,9 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose,
   const pending = Object.keys(requestedExports).length > 0 && caesarExportStatus === CAESAR_EXPORTS_STATUS.PENDING;
   const disableButton = noExport || fetching || pending;
   const success = Object.keys(caesarExport).length > 0 && caesarExportStatus === CAESAR_EXPORTS_STATUS.SUCCESS;
+  const assignmentName = (toExport.assignment && toExport.assignment.name) ? prepStringForFilename(toExport.assignment.name) : null;
+  const classroomName = (toExport.classroom && toExport.classroom.name) ? prepStringForFilename(toExport.classroom.name) : null;
+  const fileNameBase = (assignmentName && classroomName) ? `astro101-${classroomName}-${assignmentName}-` : 'astro101-';
 
   if (showModal) {
     return (
@@ -55,6 +71,24 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose,
               <Status value="warning" />{' '}
               Export request is processing. Please check again later.
             </Paragraph>}
+          {caesarExportStatus === CAESAR_EXPORTS_STATUS.EXPORTING &&
+            <Paragraph>
+              <Spinning />{' '}
+              Export to Google Drive request is processing.
+            </Paragraph>}
+          {caesarExportStatus === CAESAR_EXPORTS_STATUS.SUCCESS && googleFileUrl &&
+            <Paragraph>
+              <Status value="ok" />{' '}
+              The CSV export is now{' '}
+              <Anchor
+                href={googleFileUrl}
+                onClick={Actions.caesarExports.showModal}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                  available on your Google Drive
+                </Anchor>.
+            </Paragraph>}
           {noExport &&
             <Paragraph>
               <Status value="warning" />{' '}
@@ -75,7 +109,7 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose,
             <SuperDownloadButton
               className="export-modal__button"
               disabled={disableButton}
-              fileNameBase="astro101-"
+              fileNameBase={fileNameBase}
               primary={true}
               text="Download CSV"
               transformData={transformData}
@@ -84,6 +118,9 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose,
             <GoogleDriveExportButton
               className="export-modal__button"
               disabled={disableButton}
+              fileNameBase={fileNameBase}
+              transformData={transformData}
+              url={caesarExport.url}
             />
           </Box>
         </Box>
@@ -96,18 +133,24 @@ function ExportModal({ caesarExport, caesarExports, caesarExportStatus, onClose,
 
 ExportModal.defaultProps = {
   ...CAESAR_EXPORTS_INITIAL_STATE,
-  onClose: () => {}
+  onClose: () => {},
+  toExport: {},
 };
 
 ExportModal.propTypes = {
   ...CAESAR_EXPORTS_PROPTYPES,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  toExport: PropTypes.shape({
+    assignment: PropTypes.object,
+    classroom: PropTypes.object
+  })
 };
 
 function mapStateToProps(state) {
   return {
     caesarExport: state.caesarExports.caesarExport,
     caesarExportStatus: state.caesarExports.status,
+    googleFileUrl: state.caesarExports.googleFileUrl,
     requestedExports: state.caesarExports.requestedExports,
     showModal: state.caesarExports.showModal
   };

--- a/src/components/astro/GoogleDriveExportButton.jsx
+++ b/src/components/astro/GoogleDriveExportButton.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import Button from 'grommet/components/Button';
+import Spinning from 'grommet/components/icons/Spinning';
+import Papa from 'papaparse';
 import { config } from '../../lib/config';
+import { blobbifyData, generateFilename } from '../../lib/file-download-helpers';
+
 
 const STATUS = {
   IDLE: 'idle',
   CONFIGURING: 'configuring',
+  FETCHING: 'fetching',
   SUCCESS: 'success',
-  ERROR: 'error',
+  ERROR: 'error'
 };
 
 let GoogleAuth = null;
@@ -21,7 +25,7 @@ class GoogleDriveExportButton extends React.Component {
     this.state = {
       isAuthorized: false,
       status: STATUS.IDLE
-    }
+    };
 
     this.handleError = this.handleError.bind(this);
     this.setupGoogleClient = this.setupGoogleClient.bind(this);
@@ -45,15 +49,6 @@ class GoogleDriveExportButton extends React.Component {
     script.parentNode.removeChild(script);
   }
 
-  updateSigninStatus(isSignedIn) {
-    this.setState({ isAuthorized: isSignedIn }, this.sendAuthorizedRequest);
-  }
-
-  handleError(error) {
-    console.error(error);
-    this.setState({ error: STATUS.ERROR })
-  }
-
   setupGoogleClient() {
     if (!document.querySelector('#google-api')) {
       this.setState({ status: STATUS.CONFIGURING });
@@ -71,24 +66,49 @@ class GoogleDriveExportButton extends React.Component {
             discoveryDocs: config.googleDiscoveryDocs
           }).then(() => {
             GoogleAuth = gapi.auth2.getAuthInstance();
-            GoogleAuth.isSignedIn.listen(this.updateSigninStatus)
+            GoogleAuth.isSignedIn.listen(this.updateSigninStatus);
 
             gapi.client.load('drive', 'v3', () => {
               this.setState({ status: STATUS.SUCCESS });
             });
-          })
-        })
+          });
+        });
       };
 
       document.body.appendChild(script);
     }
   }
 
-  export() {
-    // TODO Replace body with the CSV from caesar request response
-    const testCSV = new Blob([['test', 'csv'], ['hello', 'world']], { type: 'text/csv' });
+  updateSigninStatus(isSignedIn) {
+    this.setState({ isAuthorized: isSignedIn }, this.sendAuthorizedRequest);
+  }
 
-    Actions.exportToGoogleDrive(testCSV);
+  handleError(error) {
+    console.error(error);
+    this.setState({ error: STATUS.ERROR });
+  }
+
+  export() {
+    if (this.props.transformData && typeof this.props.transformData === 'function' && this.props.url) {
+      this.setState({ status: STATUS.FETCHING });
+
+      return new Promise((resolve, reject) => {
+        return Papa.parse(this.props.url, { complete: result => resolve(result), error: error => reject(error), download: true });
+      }).then((csvData) => {
+        if (!csvData) throw 'ERROR (GoogleDriveExportButton): No CSV parsing result';
+
+        if (csvData) {
+          return this.props.transformData(csvData).then((transformedData) => {
+            return Actions.exportToGoogleDrive({
+              csv: transformedData,
+              filename: generateFilename(this.props.fileNameBase)
+            }).then(this.setState({ status: STATUS.SUCCESS }));
+          });
+        }
+      }).catch(error => this.handleError(error));
+    }
+
+    return this.handleError('ERROR (GoogleDriveExportButton): No URL available to download or no transform data function')
   }
 
   tryExport() {
@@ -98,14 +118,19 @@ class GoogleDriveExportButton extends React.Component {
       Promise.resolve(GoogleAuth.signIn())
         .then(() => {
           this.export();
-        });
+        }).catch(error => handleError(error));
     }
   }
 
   render() {
+    const disabled = (this.state.status !== STATUS.SUCCESS || this.props.disabled);
     if (this.state.status === STATUS.SUCCESS) {
       return (
-        <Button className={this.props.className || null} label="Export to Google Drive" onClick={this.props.disabled ? null : this.tryExport} />
+        <Button
+          className={this.props.className || null}
+          label="Export to Google Drive"
+          onClick={disabled ? null : this.tryExport}
+        />
       );
     }
 
@@ -114,11 +139,24 @@ class GoogleDriveExportButton extends React.Component {
 }
 
 GoogleDriveExportButton.defaultProps = {
-  disabled: false
+  className: '',
+  contentType: 'text/csv',
+  disabled: false,
+  fileNameBase: 'astro101-',
+  url: '',
+  transformData: null
 };
 
 GoogleDriveExportButton.propTypes = {
-  disabled: PropTypes.bool
+  className: PropTypes.string,
+  contentType: PropTypes.string,
+  disabled: PropTypes.bool,
+  fileNameBase: PropTypes.string,
+  url: PropTypes.string.isRequired,
+  transformData: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object
+  ]).isRequired
 };
 
 export default GoogleDriveExportButton;

--- a/src/components/common/SuperDownloadButton.jsx
+++ b/src/components/common/SuperDownloadButton.jsx
@@ -65,7 +65,7 @@ class SuperDownloadButton extends React.Component {
     if (this.props.transformData && typeof this.props.transformData === 'function') {
       this.setState({ status: STATUS.FETCHING });
 
-      new Promise((resolve, reject) => {
+      return new Promise((resolve, reject) => {
         return Papa.parse(this.props.url, { complete: result => resolve(result), error: error => reject(error), download: true });
       }).then((csvData) => {
         if (csvData) {

--- a/src/components/common/SuperDownloadButton.jsx
+++ b/src/components/common/SuperDownloadButton.jsx
@@ -50,25 +50,48 @@ class SuperDownloadButton extends React.Component {
     super(props);
     this.download = this.download.bind(this);
     this.handleClick = this.handleClick.bind(this);
+    this.saveFile = this.saveFile.bind(this);
 
     this.altForm = null;
     this.altFormData = null;
 
     this.state = {  // Keep the state simple and local; no need for Redux connections.
+      filename: generateFilename(this.props.fileNameBase),
       status: STATUS.IDLE
     };
   }
 
   handleClick() {
     if (this.props.transformData && typeof this.props.transformData === 'function') {
-      return Papa.parse(this.props.url, { complete: this.props.transformData, download: true });
+      this.setState({ status: STATUS.FETCHING });
+
+      new Promise((resolve, reject) => {
+        return Papa.parse(this.props.url, { complete: result => resolve(result), error: error => reject(error), download: true });
+      }).then((csvData) => {
+        if (csvData) {
+          this.props.transformData(csvData).then((transformedData) => {
+            this.setState({ status: STATUS.SUCCESS });
+            this.saveFile(transformedData);
+          });
+        }
+
+        throw 'ERROR (SuperDownloadButton): No CSV parsing result';
+      }).catch(error => this.handleError(error));
     }
 
     return this.download();
   }
 
+  handleError(error) {
+    this.setState({ status: STATUS.ERROR });
+    console.error(error);
+  }
+
+  saveFile(data) {
+    saveAs(blobbifyData(data, this.props.contentType), this.state.filename);
+  }
+
   download() {
-    const filename = generateFilename(this.props.fileNameBase);
     this.setState({ status: STATUS.FETCHING });
     superagent.get(this.props.url)
     .then((response) => {
@@ -92,15 +115,12 @@ class SuperDownloadButton extends React.Component {
         this.altFormData.value = data;
         this.altForm.submit();
       } else {
-        saveAs(blobbifyData(data, this.props.contentType), filename);
+        this.saveFile(data);
       }
 
       this.setState({ status: STATUS.SUCCESS });
     })
-    .catch((err) => {
-      this.setState({ status: STATUS.ERROR });
-      console.error(err);
-    });
+    .catch(error => this.handleError(error));
   }
 
   render() {
@@ -130,7 +150,7 @@ class SuperDownloadButton extends React.Component {
         >
           <textarea name="data" ref={c => this.altFormData = c} readOnly aria-label="alt-data" />
           <input name="content_type" value={this.props.contentType} readOnly aria-label="alt-contenttype" />
-          <input name="filename" value={this.props.filename} readOnly aria-label="alt-filename" />
+          <input name="filename" value={this.state.filename} readOnly aria-label="alt-filename" />
         </form>
       </Button>
     );

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -149,6 +149,7 @@ class AstroClassroomsTableContainer extends React.Component {
   }
 }
 
+<<<<<<< 63a4dfcb8459bffbb23170d6b531039f496bf935
 AstroClassroomsTableContainer.defaultProps = {
   ...CAESAR_EXPORTS_INITIAL_STATE
 };
@@ -162,6 +163,10 @@ function mapStateToProps(state) {
     caesarExport: state.caesarExports.caesarExport,
     requestedExports: state.caesarExports.requestedExports
   };
+=======
+function mapStateToProps(state) {
+  return { requestedExports: state.caesarExports.requestedExports };
+>>>>>>> Deal with export states
 }
 
 export default connect(mapStateToProps)(AstroClassroomsTableContainer);

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -11,6 +11,10 @@ import {
 } from '../../ducks/caesar-exports';
 import { i2aAssignmentNames } from '../../ducks/programs';
 
+import {
+  CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
+} from '../../ducks/caesar-exports';
+
 class AstroClassroomsTableContainer extends React.Component {
   constructor() {
     super();
@@ -64,7 +68,7 @@ class AstroClassroomsTableContainer extends React.Component {
     return Actions.getCaesarExport({ assignment, classroom, id: exportId });
   }
 
-  requestNewExport(assignment, classroom) {
+  requestNewExport(assignment = this.state.assignment, classroom = this.state.classroom) {
     return Actions.createCaesarExport({ assignment, classroom });
   }
 
@@ -149,7 +153,6 @@ class AstroClassroomsTableContainer extends React.Component {
   }
 }
 
-<<<<<<< 63a4dfcb8459bffbb23170d6b531039f496bf935
 AstroClassroomsTableContainer.defaultProps = {
   ...CAESAR_EXPORTS_INITIAL_STATE
 };
@@ -163,10 +166,6 @@ function mapStateToProps(state) {
     caesarExport: state.caesarExports.caesarExport,
     requestedExports: state.caesarExports.requestedExports
   };
-=======
-function mapStateToProps(state) {
-  return { requestedExports: state.caesarExports.requestedExports };
->>>>>>> Deal with export states
 }
 
 export default connect(mapStateToProps)(AstroClassroomsTableContainer);

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -5,14 +5,11 @@ import { saveAs } from 'browser-filesaver';
 
 import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
 import { blobbifyData, generateFilename } from '../../lib/file-download-helpers';
-<<<<<<< 8e051432828e13291b68113e43f72636c1b5415f
 
 import {
   CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
 } from '../../ducks/caesar-exports';
 import { i2aAssignmentNames } from '../../ducks/programs';
-=======
->>>>>>> Hubble's Law export data transformation
 
 import {
   CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
@@ -46,17 +43,9 @@ class AstroClassroomsTableContainer extends React.Component {
   }
 
   showExportModal(assignment, classroom) {
-    const localStorageExport = JSON.parse(localStorage.getItem('pendingExport'));
     this.setState({ toExport: { assignment, classroom } });
 
     Actions.caesarExports.showModal();
-
-    if (localStorageExport &&
-        !this.props.requestNewExport[classroom.id] &&
-        localStorageExport[classroom.id] &&
-        localStorageExport[classroom.id].workflow_id.toString() === assignment.workflowId) {
-      this.checkPendingExport(assignment, classroom, localStorageExport[classroom.id].id);
-    }
 
     if (Object.keys(this.props.requestedExports).length > 0 &&
         this.props.requestedExports[classroom.id] &&
@@ -64,7 +53,7 @@ class AstroClassroomsTableContainer extends React.Component {
       this.checkPendingExport(assignment, classroom, this.props.requestedExports[classroom.id].id);
     }
 
-    if (Object.keys(this.props.requestedExports).length === 0 && !localStorageExport) {
+    if (Object.keys(this.props.requestedExports).length === 0) {
       this.checkExportExistence(assignment, classroom)
         .then((caesarExports) => {
           if (caesarExports && caesarExports.length === 0) {

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -14,6 +14,7 @@ import { i2aAssignmentNames } from '../../ducks/programs';
 import {
   CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
 } from '../../ducks/caesar-exports';
+import { i2aAssignmentNames } from '../../ducks/programs';
 
 class AstroClassroomsTableContainer extends React.Component {
   constructor() {
@@ -29,6 +30,7 @@ class AstroClassroomsTableContainer extends React.Component {
     this.handleRequestForNewExport = this.handleRequestForNewExport.bind(this);
     this.onExportModalClose = this.onExportModalClose.bind(this);
     this.handleRequestForNewExport = this.handleRequestForNewExport.bind(this);
+    this.onExportModalClose = this.onExportModalClose.bind(this);
     this.showExportModal = this.showExportModal.bind(this);
     this.transformData = this.transformData.bind(this);
   }

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -28,6 +28,7 @@ class AstroClassroomsTableContainer extends React.Component {
 
     this.handleRequestForNewExport = this.handleRequestForNewExport.bind(this);
     this.onExportModalClose = this.onExportModalClose.bind(this);
+    this.handleRequestForNewExport = this.handleRequestForNewExport.bind(this);
     this.showExportModal = this.showExportModal.bind(this);
     this.transformData = this.transformData.bind(this);
   }
@@ -40,9 +41,18 @@ class AstroClassroomsTableContainer extends React.Component {
   }
 
   showExportModal(assignment, classroom) {
+    const localStorageExport = JSON.parse(localStorage.getItem('pendingExport'));
     this.setState({ toExport: { assignment, classroom } });
 
     Actions.caesarExports.showModal();
+
+    if (localStorageExport &&
+        !this.props.requestNewExport[classroom.id] &&
+        localStorageExport[classroom.id] &&
+        localStorageExport[classroom.id].workflow_id.toString() === assignment.workflowId) {
+      console.log('pendingExport in localStorage')
+      this.checkPendingExport(assignment, classroom, localStorageExport[classroom.id].id);
+    }
 
     if (Object.keys(this.props.requestedExports).length > 0 &&
         this.props.requestedExports[classroom.id] &&
@@ -50,7 +60,8 @@ class AstroClassroomsTableContainer extends React.Component {
       this.checkPendingExport(assignment, classroom, this.props.requestedExports[classroom.id].id);
     }
 
-    if (Object.keys(this.props.requestedExports).length === 0) {
+    if (Object.keys(this.props.requestedExports).length === 0 && !localStorageExport) {
+      console.log('no requestedExports')
       this.checkExportExistence(assignment, classroom)
         .then((caesarExports) => {
           if (caesarExports && caesarExports.length === 0) {
@@ -68,7 +79,7 @@ class AstroClassroomsTableContainer extends React.Component {
     return Actions.getCaesarExport({ assignment, classroom, id: exportId });
   }
 
-  requestNewExport(assignment = this.state.assignment, classroom = this.state.classroom) {
+  requestNewExport(assignment, classroom) {
     return Actions.createCaesarExport({ assignment, classroom });
   }
 

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -9,11 +9,6 @@ import {
 } from '../../ducks/caesar-exports';
 import { i2aAssignmentNames } from '../../ducks/programs';
 
-import {
-  CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
-} from '../../ducks/caesar-exports';
-import { i2aAssignmentNames } from '../../ducks/programs';
-
 class AstroClassroomsTableContainer extends React.Component {
   constructor() {
     super();

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { Actions } from 'jumpstate';
 import { connect } from 'react-redux';
-import { saveAs } from 'browser-filesaver';
 
 import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
-import { blobbifyData, generateFilename } from '../../lib/file-download-helpers';
 
 import {
   CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
@@ -84,13 +82,9 @@ class AstroClassroomsTableContainer extends React.Component {
 
   transformData(csvData) {
     if (this.state.toExport.assignment.name === i2aAssignmentNames.galaxy) {
-      Promise.resolve(this.transformGalaxyDataCsv(csvData));
+      return Promise.resolve(this.transformGalaxyDataCsv(csvData));
     } else if (this.state.toExport.assignment.name === i2aAssignmentNames.hubble) {
-      Promise.resolve(this.transformHubbleDataCsv(csvData))
-        .then((transformedData) => {
-          const filename = generateFilename('astro101-');
-          saveAs(blobbifyData(transformedData, 'text/csv'), filename);
-        });
+      return Promise.resolve(this.transformHubbleDataCsv(csvData));
     }
 
     return null;
@@ -144,7 +138,7 @@ class AstroClassroomsTableContainer extends React.Component {
     return (
       <AstroClassroomsTable
         {...this.props}
-        assignmentToExport={this.state.toExport.assignment}
+        toExport={this.state.toExport}
         onExportModalClose={this.onExportModalClose}
         requestNewExport={this.handleRequestForNewExport}
         showExportModal={this.showExportModal}

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -32,6 +32,8 @@ class AstroClassroomsTableContainer extends React.Component {
     this.setState({ toExport: { assignment: {}, classroom: {} } });
 
     Actions.caesarExports.setCaesarExport(CAESAR_EXPORTS_INITIAL_STATE.caesarExport);
+    Actions.caesarExports.setGoogleFileUrl(CAESAR_EXPORTS_INITIAL_STATE.googleFileUrl);
+    Actions.caesarExports.setStatus(CAESAR_EXPORTS_INITIAL_STATE.status);
     Actions.caesarExports.showModal();
   }
 
@@ -44,9 +46,7 @@ class AstroClassroomsTableContainer extends React.Component {
         this.props.requestedExports[classroom.id] &&
         this.props.requestedExports[classroom.id].workflow_id.toString() === assignment.workflowId) {
       this.checkPendingExport(assignment, classroom, this.props.requestedExports[classroom.id].id);
-    }
-
-    if (Object.keys(this.props.requestedExports).length === 0) {
+    } else {
       this.checkExportExistence(assignment, classroom)
         .then((caesarExports) => {
           if (caesarExports && caesarExports.length === 0) {

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -55,7 +55,6 @@ class AstroClassroomsTableContainer extends React.Component {
         !this.props.requestNewExport[classroom.id] &&
         localStorageExport[classroom.id] &&
         localStorageExport[classroom.id].workflow_id.toString() === assignment.workflowId) {
-      console.log('pendingExport in localStorage')
       this.checkPendingExport(assignment, classroom, localStorageExport[classroom.id].id);
     }
 
@@ -66,7 +65,6 @@ class AstroClassroomsTableContainer extends React.Component {
     }
 
     if (Object.keys(this.props.requestedExports).length === 0 && !localStorageExport) {
-      console.log('no requestedExports')
       this.checkExportExistence(assignment, classroom)
         .then((caesarExports) => {
           if (caesarExports && caesarExports.length === 0) {

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -5,11 +5,14 @@ import { saveAs } from 'browser-filesaver';
 
 import AstroClassroomsTable from '../../components/astro/AstroClassroomsTable';
 import { blobbifyData, generateFilename } from '../../lib/file-download-helpers';
+<<<<<<< 8e051432828e13291b68113e43f72636c1b5415f
 
 import {
   CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES
 } from '../../ducks/caesar-exports';
 import { i2aAssignmentNames } from '../../ducks/programs';
+=======
+>>>>>>> Hubble's Law export data transformation
 
 import {
   CAESAR_EXPORTS_INITIAL_STATE, CAESAR_EXPORTS_PROPTYPES

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -20,6 +20,7 @@ const CAESAR_EXPORTS_STATUS = {
 const CAESAR_EXPORTS_INITIAL_STATE = {
   caesarExport: {},
   error: null,
+  googleFileUrl: null,
   requestedExports: {},
   showModal: false,
   status: CAESAR_EXPORTS_STATUS.IDLE
@@ -28,6 +29,7 @@ const CAESAR_EXPORTS_INITIAL_STATE = {
 const CAESAR_EXPORTS_PROPTYPES = {
   caesarExport: PropTypes.shape({}),
   error: PropTypes.object,
+  googleFileUrl: PropTypes.string,
   requestedExports: PropTypes.object,
   showModal: PropTypes.bool,
   status: PropTypes.string
@@ -54,10 +56,14 @@ const setError = (state, error) => {
   return { ...state, error };
 };
 
+const setGoogleFileUrl = (state, googleFileUrl) => {
+  return { ...state, googleFileUrl };
+};
+
 const setRequestedExports = (state, newRequestedExport) => {
   const mergedRequestedExports = Object.assign({}, state.requestedExports, newRequestedExport);
   return { ...state, requestedExports: mergedRequestedExports };
-}
+};
 
 const showModal = (state) => {
   return { ...state, showModal: !state.showModal };
@@ -202,7 +208,7 @@ Effect('createCaesarExport', (data) => {
     });
 });
 
-Effect('exportToGoogleDrive', (csv) => {
+Effect('exportToGoogleDrive', (data) => {
   // This is using the multipart upload as specified in the Google Drive v3 REST API documentation
   // https://developers.google.com/drive/v3/web/multipart-upload
   // And borrows a lot from this stack overflow example
@@ -211,27 +217,32 @@ Effect('exportToGoogleDrive', (csv) => {
   const delimiter = `\r\n--${boundary}\r\n`;
   const closeDelim = `\r\n--${boundary}--`;
   const metadata = {
-    name: 'Test', // Replace with actual file name
+    name: data.filename,
     mimeType: 'application/vnd.google-apps.spreadsheet'
   };
-  const multipartRequestBody = `${delimiter}Content-Type: application/json\r\n\r\n${JSON.stringify(metadata)}${delimiter}Content-Type: text/csv\r\n\r\n${csv}${closeDelim}`;
+  const multipartRequestBody = `${delimiter}Content-Type: application/json\r\n\r\n${JSON.stringify(metadata)}${delimiter}Content-Type: text/csv\r\n\r\n${data.csv}${closeDelim}`;
 
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.EXPORTING);
 
-
-  return gapi.client.request({
+  const gapi = window.gapi;
+  if (gapi) {
+    return gapi.client.request({
       path: 'https://www.googleapis.com/upload/drive/v3/files',
       method: 'POST',
-      params: { uploadType: 'multipart' },
+      params: { uploadType: 'multipart', fields: 'webViewLink' },
       headers: { 'Content-Type': `multipart/related; boundary="${boundary}"` },
       body: multipartRequestBody
     }).then((response) => {
       if (response && response.body && response.status === 200) {
+        const parsedResponse = JSON.parse(response.body);
+
+        Actions.caesarExports.setGoogleFileUrl(parsedResponse.webViewLink);
         Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
-        Actions.classrooms.setToastState({ status: 'ok', message: 'Sent CSV to your Google Drive' });
-        Actions.caesarExports.showModal();
       }
     }).catch((error) => { handleError(error); });
+  }
+
+  return Promise.resolve(null);
 });
 
 const caesarExports = State('caesarExports', {
@@ -241,6 +252,7 @@ const caesarExports = State('caesarExports', {
   setStatus,
   setCaesarExport,
   setError,
+  setGoogleFileUrl,
   setRequestedExports,
   showModal
 });

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -125,7 +125,10 @@ Effect('getCaesarExports', (data) => {
 });
 
 Effect('getCaesarExport', (data) => {
+<<<<<<< dcabd0eec4fb8cb0139611fe908fbc8da4e758b5
   let requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/new`;
+=======
+>>>>>>> localStorage will be too fussy
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
   const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/${data.id}`;
 
@@ -148,7 +151,6 @@ Effect('getCaesarExport', (data) => {
         if (responseData.status === 'pending') {
           Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.PENDING);
           const requestedExport = { [data.classroom.id]: responseData };
-          localStorage.setItem('pendingExport', JSON.stringify(requestedExport));
           Actions.caesarExports.setRequestedExports(requestedExport);
         }
 

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -18,7 +18,6 @@ const CAESAR_EXPORTS_STATUS = {
 
 // Initial State and PropTypes - usable in React components.
 const CAESAR_EXPORTS_INITIAL_STATE = {
-  caesarExports: [],
   caesarExport: {},
   error: null,
   requestedExports: {},
@@ -27,7 +26,6 @@ const CAESAR_EXPORTS_INITIAL_STATE = {
 };
 
 const CAESAR_EXPORTS_PROPTYPES = {
-  caesarExports: PropTypes.arrayOf(PropTypes.object),
   caesarExport: PropTypes.shape({}),
   error: PropTypes.object,
   requestedExports: PropTypes.object,
@@ -150,6 +148,7 @@ Effect('getCaesarExport', (data) => {
         if (responseData.status === 'pending') {
           Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.PENDING);
           const requestedExport = { [data.classroom.id]: responseData };
+          localStorage.setItem('pendingExport', JSON.stringify(requestedExport));
           Actions.caesarExports.setRequestedExports(requestedExport);
         }
 

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -125,6 +125,7 @@ Effect('getCaesarExports', (data) => {
 });
 
 Effect('getCaesarExport', (data) => {
+  let requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/new`;
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
   const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/${data.id}`;
 

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -145,9 +145,9 @@ Effect('getCaesarExport', (data) => {
         if (responseData.status === 'complete') {
           Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.SUCCESS);
           Actions.caesarExports.setCaesarExport(responseData);
-          Actions.caesarExports.setRequestedExports(CAESAR_EXPORTS_INITIAL_STATE.requestedExport);
+          Actions.caesarExports.setRequestedExports({ [data.classroom.id]: undefined });
 
-          return response.body;
+          return responseData;
         }
 
         if (responseData.status === 'pending') {

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -131,10 +131,6 @@ Effect('getCaesarExports', (data) => {
 });
 
 Effect('getCaesarExport', (data) => {
-<<<<<<< dcabd0eec4fb8cb0139611fe908fbc8da4e758b5
-  let requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/new`;
-=======
->>>>>>> localStorage will be too fussy
   Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.FETCHING);
   const requestUrl = `${config.caesar}/workflows/${data.assignment.workflowId}/data_requests/${data.id}`;
 

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -18,6 +18,7 @@ const CAESAR_EXPORTS_STATUS = {
 
 // Initial State and PropTypes - usable in React components.
 const CAESAR_EXPORTS_INITIAL_STATE = {
+  caesarExports: [],
   caesarExport: {},
   error: null,
   requestedExports: {},
@@ -26,6 +27,7 @@ const CAESAR_EXPORTS_INITIAL_STATE = {
 };
 
 const CAESAR_EXPORTS_PROPTYPES = {
+  caesarExports: PropTypes.arrayOf(PropTypes.object),
   caesarExport: PropTypes.shape({}),
   error: PropTypes.object,
   requestedExports: PropTypes.object,


### PR DESCRIPTION
This closes #26 and should merge after #95. 

I've refactored the Papaparse function to be wrapped in a promised and moved it into the `AstroClassroomsTableContainer`. I've also refactored the export to Google drive to use the actual transformed CSV data. The UI received some improvements including status messages about the export and the modal will remain open to offer a link to open the CSV in Google Sheets. I'm a bit unsure with this UI state since I'm showing two success messages: one that an export from caesar is available, and the other is that the CSV successfully exported to Google Sheets and the URL link. 

Still to do: The CSV transformation for the galaxy zoo project. 