### PR TITLE
Assignment create

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js $(find src -name *.spec.jsx) --compilers js:babel-core/register --require mock-local-storage || true",
     "eslint": "eslint .",
     "build": "export BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
+    "deploy-staging": "export NODE_ENV=staging; npm run build && publisssh dist zooniverse-static/preview.zooniverse.org/classroom",
     "deploy-production": "export NODE_ENV=production; npm run build && publisssh dist zooniverse-static/classroom.zooniverse.org"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/zooniverse/edu-api-front-end"
   },
   "scripts": {
-    "start": "BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack-dev-server --config ./webpack.config.js",
+    "start": "export NODE_ENV=development; BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3999 -- webpack-dev-server --config ./webpack.config.js",
     "test": "NODE_ENV=development BABEL_ENV=test mocha mocha-setup.js $(find src -name *.spec.jsx) --compilers js:babel-core/register --require mock-local-storage || true",
     "eslint": "eslint .",
     "build": "export BABEL_ENV=production; check-engines && check-dependencies && webpack --config webpack.production.config.js -p",

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -50,7 +50,7 @@ function AstroClassroomsTable(props) {
           </TableRow>
         </thead>
         {props.classrooms.map((classroom) => {
-          const joinURL = `${window.location.host}/#/${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
+          const joinURL = `${config.origin}/#/${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
           // Can we get linked assignments with classrooms in single get request?
           // No, if we want this, then we need to open an issue with the API
           // TODO replace classifications_target with calculated percentage

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -29,10 +29,11 @@ import {
   ASSIGNMENTS_STATUS
 } from '../../ducks/assignments';
 import { i2aAssignmentNames } from '../../ducks/programs';
+import { config } from '../../lib/config';
 
 const ClassroomEditor = (props) => {
   const joinURL = props.selectedClassroom ?
-    `${window.location.host}/#/${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}` :
+    `${config.origin}/#/${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}` :
     '';
 
   // Get students and assignments only for this classroom.

--- a/src/containers/assignments/AssignmentFormContainer.jsx
+++ b/src/containers/assignments/AssignmentFormContainer.jsx
@@ -12,6 +12,7 @@ import {
 import {
   PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
 } from '../../ducks/programs';
+import { env } from '../../lib/config';
 
 export class AssignmentFormContainer extends React.Component {
   constructor() {
@@ -76,6 +77,31 @@ export class AssignmentFormContainer extends React.Component {
       }
     };
 
+    // Wildcam programs
+    const selectedProgram = this.props.selectedProgram;
+    if (selectedProgram && selectedProgram.custom) {
+      assignmentData.attributes.workflow_id = selectedProgram.metadata.workflowId;
+
+      // need to add working filters form field to assignment create form
+      // assignmentData.attributes.metadata.filters = this.props.formFields.filters;
+      if (env === 'staging' || env === 'development') {
+        const sampleSubjects = selectedProgram.metadata.sampleSubjects;
+        assignmentData.attributes.metadata.subjects = sampleSubjects;
+        const subjectData = sampleSubjects.map((subjectId) => {
+          return { id: subjectId, type: 'subjects' };
+        });
+        assignmentData.relationships.subjects.data = subjectData;
+      } else {
+        // need to add working subjects form field to assignment create form
+        const subjects = this.props.formFields.subjects;
+        assignmentData.attributes.metadata.subjects = subjects;
+        const subjectData = subjects.map((subjectId) => {
+          return { id: subjectId, type: 'subjects' };
+        });
+        assignmentData.relationships.subject.data = subjectData;
+      }
+    }
+
     return Actions.createAssignment(assignmentData);
   }
 
@@ -104,19 +130,22 @@ export class AssignmentFormContainer extends React.Component {
 
 AssignmentFormContainer.defaultProps = {
   ...ASSIGNMENTS_INITIAL_STATE,
-  ...CLASSROOMS_INITIAL_STATE
+  ...CLASSROOMS_INITIAL_STATE,
+  ...PROGRAMS_INITIAL_STATE
 };
 
 AssignmentFormContainer.propTypes = {
   ...ASSIGNMENTS_PROPTYPES,
-  ...CLASSROOMS_PROPTYPES
+  ...CLASSROOMS_PROPTYPES,
+  ...PROGRAMS_PROPTYPES
 };
 
 function mapStateToProps(state) {
   return {
     formFields: state.assignments.formFields,
     selectedAssignment: state.assignments.selectedAssignment,
-    selectedClassroomToLink: state.assignments.selectedClassroomToLink
+    selectedClassroomToLink: state.assignments.selectedClassroomToLink,
+    selectedProgram: state.programs.selectedProgram
   };
 }
 

--- a/src/containers/assignments/AssignmentFormContainer.jsx
+++ b/src/containers/assignments/AssignmentFormContainer.jsx
@@ -73,14 +73,14 @@ export class AssignmentFormContainer extends React.Component {
             id: this.props.selectedClassroomToLink.id,
             type: 'classrooms'
           }
-        },
-        subjects: {}
+        }
       }
     };
 
     // Wildcam programs
     const selectedProgram = this.props.selectedProgram;
     if (selectedProgram && selectedProgram.custom) {
+      assignmentData.relationships.subjects = {};
       assignmentData.attributes.workflow_id = selectedProgram.metadata.workflowId;
 
       // need to add working filters form field to assignment create form

--- a/src/containers/assignments/AssignmentFormContainer.jsx
+++ b/src/containers/assignments/AssignmentFormContainer.jsx
@@ -73,7 +73,8 @@ export class AssignmentFormContainer extends React.Component {
             id: this.props.selectedClassroomToLink.id,
             type: 'classrooms'
           }
-        }
+        },
+        subjects: {}
       }
     };
 
@@ -98,7 +99,7 @@ export class AssignmentFormContainer extends React.Component {
         const subjectData = subjects.map((subjectId) => {
           return { id: subjectId, type: 'subjects' };
         });
-        assignmentData.relationships.subject.data = subjectData;
+        assignmentData.relationships.subjects.data = subjectData;
       }
     }
 

--- a/src/ducks/assignments.js
+++ b/src/ducks/assignments.js
@@ -33,8 +33,11 @@ const assignmentPropTypes = {
     classifications_target: PropTypes.string,
     description: PropTypes.string,
     duedate: PropTypes.string,
+    filters: PropTypes.object,
+    subjects: PropTypes.arrayOf(PropTypes.string)
   },
-  name: PropTypes.string
+  name: PropTypes.string,
+  workflow_id: PropTypes.string
 };
 
 const ASSIGNMENTS_PROPTYPES = {

--- a/src/ducks/auth.js
+++ b/src/ducks/auth.js
@@ -1,5 +1,6 @@
 import { State, Effect, Actions } from 'jumpstate';
 import oauth from 'panoptes-client/lib/oauth';
+import { config } from '../lib/config';
 
 // Constants
 const AUTH_STATUS = {
@@ -10,10 +11,8 @@ const AUTH_STATUS = {
 };
 
 // Helper functions
-const computeRedirectURL = (window) => {
-  const { location } = window;
-  return location.origin ||
-    `${location.protocol}//${location.hostname}:${location.port}`;
+const computeRedirectURL = () => {
+  return config.origin;
 };
 
 function handleError(error) {
@@ -59,7 +58,7 @@ Effect('checkLoginUser', () => {
 
 Effect('loginToPanoptes', () => {
   // Returns a login page URL for the user to navigate to.
-  oauth.signIn(computeRedirectURL(window))
+  oauth.signIn(computeRedirectURL())
     .catch((error) => {
       handleError(error);
     });

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -28,7 +28,6 @@ const i2a = {
         // back to a project without having to request that from Panoptes
         // to then build the URL to the project in the UI.
         // These are just test projects on staging...
-        // classifications_target should be a string?
         "2218": {
           name: i2aAssignmentNames.hubble,
           classifications_target: "10",
@@ -57,7 +56,6 @@ const i2a = {
         // used to relate the assignment resource that has a workflow id property
         // back to a project without having to request that from Panoptes
         // to then build the URL to the project in the UI.
-        // TODO: replace the workflow ids here with the production ids
         "1315": {
           name: i2aAssignmentNames.hubble,
           classifications_target: "10",
@@ -84,6 +82,8 @@ const darien = {
       backgroundImage: '',
       cardImage: 'home-card-wildcam-darien.jpg',
       redirectOnJoin: true,
+      sampleSubjects: ['73437', '73438', '73434'],
+      workflowId: '3116' // belongs to project 1807
     }
   },
   production: {
@@ -96,6 +96,8 @@ const darien = {
       backgroundImage: '',
       cardImage: 'home-card-wildcam-darien.jpg',
       redirectOnJoin: true,
+      sampleSubjects: [],
+      workflowId: '3033' // belongs to project 3525
     }
   }
 };
@@ -109,7 +111,11 @@ const gorongosa = {
     slug: 'wildcam-gorongosa-lab',
     metadata: {
       cardImage: 'gorongosa-animals.jpg',
-      redirect: 'https://lab.wildcamgorongosa.org/'
+      redirect: 'https://lab.wildcamgorongosa.org/',
+      // We used hard coded sample subject ids because the Carto DB is only for production
+      // These are used in the assignment creation in development so that the POST works
+      sampleSubjects: ['37763', '37755', '37767'],
+      workflowId: '1549' // Belongs to project 937
     }
   },
   production: {
@@ -120,7 +126,9 @@ const gorongosa = {
     slug: 'wildcam-gorongosa-lab',
     metadata: {
       cardImage: 'gorongosa-animals.jpg',
-      redirect: 'https://lab.wildcamgorongosa.org/'
+      redirect: 'https://lab.wildcamgorongosa.org/',
+      sampleSubjects: [],
+      workflowId: '338' // belongs to project 593
     }
   }
 }

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -165,7 +165,10 @@ const PROGRAMS_INITIAL_STATE = {
 };
 
 const programPropTypes = {
+  custom: PropTypes.bool,
   description: PropTypes.string,
+  id: PropTypes.string,
+  metadata: PropTypes.object,
   name: PropTypes.string,
   slug: PropTypes.string
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -28,6 +28,19 @@ const baseConfig = {
     googleClientId: '460639483341-77spp98rnt01nhrn0mbimdhh3pi44nhl.apps.googleusercontent.com',
     googleScope: 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.appdata',
     googleDiscoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
+    origin: window.location.origin,
+    panoptesAppId: '397e9bf4e29e75c0a092261ebe3338d3ef2687f2c5935d55c7ca0f63ecc2dd33',
+    root: 'https://education-api-staging.zooniverse.org',
+    zooniverse: 'https://master.pfe-preview.zooniverse.org'
+  },
+  staging: {
+    caesar: 'https://caesar-staging.zooniverse.org',
+    google: 'https://apis.google.com/js/client.js',
+    googleApiKey: 'AIzaSyDknAC_jN4mCzLD6rhFsWiV1bJQt1BMj9Y',
+    googleClientId: '460639483341-77spp98rnt01nhrn0mbimdhh3pi44nhl.apps.googleusercontent.com',
+    googleScope: 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.appdata',
+    googleDiscoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
+    origin: `${window.location.origin}/classroom`,
     panoptesAppId: '397e9bf4e29e75c0a092261ebe3338d3ef2687f2c5935d55c7ca0f63ecc2dd33',
     root: 'https://education-api-staging.zooniverse.org',
     zooniverse: 'https://master.pfe-preview.zooniverse.org'
@@ -39,12 +52,12 @@ const baseConfig = {
     googleClientId: '460639483341-77spp98rnt01nhrn0mbimdhh3pi44nhl.apps.googleusercontent.com',
     googleScope: 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/drive.appdata',
     googleDiscoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
+    origin: window.location.origin,
     panoptesAppId: '47f9799996f91be6d0ee386dbcf044fcb43a37b4d07ac1b0787002111e61a152',
     root: 'https://education-api.zooniverse.org',
     zooniverse: 'https://www.zooniverse.org'
   }
 };
-baseConfig.staging = baseConfig.development;
 
 const config = baseConfig[env];
 export { env, config };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = {
     // new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('staging')
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
     }),
     new DashboardPlugin({ port: 3999 })
   ],


### PR DESCRIPTION
This preps the assignment creation for Wildcam Darien including:

- Setting up a staging environment variable
- Adding the hard coded workflow ids and sample subjects to WD and WG program mocks
- Checking for the staging environment and using the appropriate hard coded workflow and sample subject ids if it applies on assignment create
- Updates propTypes where needed

This also includes some fixes for the join link and a deploy to staging npm script. I've already deployed to staging via a different branch because I wanted the I2A instructors to start to test features for me this week on staging. The staging environment update and script were cherry picked on to this branch to come in with this PR. 

Note that the assignment create still doesn't work due to noted permissions issue in the slack channel. 