### PR TITLE
Fix button hover and focus styles

### DIFF
--- a/src/components/astro/AstroHome.jsx
+++ b/src/components/astro/AstroHome.jsx
@@ -53,7 +53,7 @@ const AstroHome = (props) => {
           </Section>
           {!signedIn &&
             <Section align="center">
-              <Button type="button" className="button" onClick={Actions.auth.toggleOauthModal} label="Sign In" />
+              <Button type="button" className="button--secondary" onClick={Actions.auth.toggleOauthModal} label="Sign In" />
             </Section>}
         </Box>
       </Hero>
@@ -68,7 +68,7 @@ const AstroHome = (props) => {
           justify="center"
         >
           <Box className="astro-home__guide" align="center" direction="row" size="xxlarge">
-            <Button href="https://drive.google.com/drive/folders/0B18vKHxr-rUfaHJXczZrSDc3dTA" type="button" label="Instructors Guide" target="_blank" rel="noopener noreferrer" />
+            <Button className="button--secondary" href="https://drive.google.com/drive/folders/0B18vKHxr-rUfaHJXczZrSDc3dTA" type="button" label="Instructors Guide" target="_blank" rel="noopener noreferrer" />
             <Paragraph align="start">
                 Instructors Guide: This provides you with a suggested timeline, lesson plans and student instructions for the class activities that will  guide the students in how to use the tools and the research project where students demonstrate the skills they have learned.
             </Paragraph>

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -100,7 +100,7 @@ const ClassroomEditor = (props) => {
           </Box>
 
           <CopyToClipboard
-            className="join-link"
+            className="join-link__button"
             text={joinURL}
             onCopy={() => { Actions.classrooms.setToastState({ status: 'ok', message: 'Copied join link.' }); }}
           >
@@ -108,6 +108,7 @@ const ClassroomEditor = (props) => {
           </CopyToClipboard>
 
           <Button
+            className="button--primary"
             type="button"
             primary={true}
             label="Export Stats"

--- a/src/components/classrooms/ClassroomForm.jsx
+++ b/src/components/classrooms/ClassroomForm.jsx
@@ -58,7 +58,7 @@ const ClassroomForm = (props) => {
         </FormField>
       </fieldset>
       <Footer>
-        <Button type="submit" label={props.submitLabel} primary={true} />
+        <Button className="button--primary" type="submit" label={props.submitLabel} primary={true} />
       </Footer>
     </Form>
   );

--- a/src/components/classrooms/ClassroomsManager.jsx
+++ b/src/components/classrooms/ClassroomsManager.jsx
@@ -21,7 +21,13 @@ const ClassroomsManager = (props) => {
     <Box className="classrooms-manager">
       <Box className="classrooms-manager__instructions" align="center" direction="row" justify="between" size="xxlarge">
         <Paragraph align="start" size="small">{props.classroomInstructions}</Paragraph>
-        <Button type="button" primary={true} label="Create New Classroom" onClick={props.toggleFormVisibility} />
+        <Button
+          className="button--primary"
+          type="button"
+          primary={true}
+          label="Create New Classroom"
+          onClick={props.toggleFormVisibility}
+        />
       </Box>
       {props.showForm &&
         <Layer closer={true} onClose={props.toggleFormVisibility}>

--- a/src/styles/components/classroom-editor.styl
+++ b/src/styles/components/classroom-editor.styl
@@ -74,6 +74,12 @@
     .grommetux-table__table
       margin: 0
 
-  .join-link
+  .join-link__button
     margin-left: 2em
     margin-right: 2em
+
+    &:hover, &:focus
+      background-color: #004b54
+      border-color: #004b54 !important
+      color: white !important
+

--- a/src/styles/global/buttons.styl
+++ b/src/styles/global/buttons.styl
@@ -29,11 +29,18 @@ $reset-button
 
 .button
   font-family: "Roboto Mono", monospace
-  border-color: #acdcdf !important
   border-width: 1px
 
-  &:hover, &focus
-    background: #acdcdf
+  &--primary
+    &:hover, &:focus
+      background: #004b54
+      border-color: #004b54 !important
+
+  &--secondary
+    border-color: #acdcdf !important
+
+    &:hover, &focus
+      background: #acdcdf
 
 .link-like-button
   @extends .button


### PR DESCRIPTION
Grommet should be handling the hover and focus styles, but I think there's a bug when the button is the child of several Box components that have background color index props set. This adds some styles to make sure the buttons get hover and focus styles. 