### PR TITLE
Remove using program mock in state on 404

### DIFF
--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -238,16 +238,7 @@ Effect('getPrograms', () => {
         return sortedPrograms;
       }
       throw 'ERROR (ducks/programs/getPrograms): Invalid response';
-    }).catch((error) => {
-      if (error.status !== 404) handleError(error);
-      if (error.status === 404) {
-        // Fallback to showing the mocks
-        // This is temporary until the production API is deployed with programs support.
-        console.log('Programs set in the redux store are the mocks');
-        Actions.programs.setStatus(PROGRAMS_STATUS.SUCCESS);
-        Actions.programs.setPrograms(programsArray);
-      }
-    });
+    }).catch(error => handleError(error));
 });
 
 Effect('getProgram', (data) => {


### PR DESCRIPTION
Removes using the mocks on 404 for the programs request. This was used previously for demo purposes while production didn't support programs yet.