### PR TITLE
A few minor I2A tweaks

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -26,7 +26,7 @@ function calculateCompleteness(assignment, classroom) {
   const numberOfStudents = assignment.studentAssignments.length;
   const numberOfCompletedClassifications = classroom.classificationsCount;
   if (numberOfStudents === 0) return 0;
-  return (numberOfCompletedClassifications / (classificationsTarget * numberOfStudents)) * 100;
+  return (Math.round(numberOfCompletedClassifications / (classificationsTarget * numberOfStudents)) * 100);
 }
 
 function AstroClassroomsTable(props) {

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -225,8 +225,8 @@ const ClassroomEditor = (props) => {
                 const hubbleStudentData = hubbleAssignment[0].studentAssignmentsData.filter(
                   data => data.attributes.student_user_id.toString() === student.id);
 
-                const galaxyPercentage = `${(galaxyStudentData[0].attributes.classifications_count / (+galaxyAssignment[0].metadata.classifications_target)) * 100}%`;
-                const hubblePercentage = `${(hubbleStudentData[0].attributes.classifications_count / (+hubbleAssignment[0].metadata.classifications_target)) * 100}%`;
+                const galaxyPercentage = `${Math.round((galaxyStudentData[0].attributes.classifications_count / (+galaxyAssignment[0].metadata.classifications_target)) * 100)}%`;
+                const hubblePercentage = `${Math.round((hubbleStudentData[0].attributes.classifications_count / (+hubbleAssignment[0].metadata.classifications_target)) * 100)}%`;
 
                 const galaxyCount = `${galaxyStudentData[0].attributes.classifications_count} / ${+galaxyAssignment[0].metadata.classifications_target}`;
                 const hubbleCount = `${hubbleStudentData[0].attributes.classifications_count} / ${+hubbleAssignment[0].metadata.classifications_target}`;

--- a/src/components/classrooms/ClassroomForm.jsx
+++ b/src/components/classrooms/ClassroomForm.jsx
@@ -8,10 +8,17 @@ import Heading from 'grommet/components/Heading';
 import Footer from 'grommet/components/Footer';
 import Paragraph from 'grommet/components/Paragraph';
 
-const ClassroomForm = (props) => {
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES, CLASSROOMS_STATUS
+} from '../../ducks/classrooms';
+
+function ClassroomForm(props) {
   const optional = props.optionalFormFields;
   return (
-    <Form onSubmit={props.onSubmit} pad="medium">
+    <Form
+      onSubmit={props.classroomsStatus === CLASSROOMS_STATUS.CREATING ? null : props.onSubmit}
+      pad="medium"
+    >
       <Heading tag="h2">{props.heading}</Heading>
       <fieldset>
         <legend><Paragraph size="small">Input the class name and if applicable the section name</Paragraph></legend>
@@ -21,7 +28,7 @@ const ClassroomForm = (props) => {
             placeHolder="Class name"
             onDOMChange={props.onChange}
             required={true}
-            value={props.fields.name}
+            value={props.formFields.name}
           />
         </FormField>
       </fieldset>
@@ -35,7 +42,7 @@ const ClassroomForm = (props) => {
             placeHolder="Class subject"
             onDOMChange={props.onChange}
             required={!optional}
-            value={props.fields.subject || ''}
+            value={props.formFields.subject || ''}
           />
         </FormField>
         <FormField htmlFor="school" label="Institution">
@@ -44,7 +51,7 @@ const ClassroomForm = (props) => {
             placeHolder="Name of institution or school"
             onDOMChange={props.onChange}
             required={!optional}
-            value={props.fields.school || ''}
+            value={props.formFields.school || ''}
           />
         </FormField>
         <FormField htmlFor="description" label="Description">
@@ -53,7 +60,7 @@ const ClassroomForm = (props) => {
             placeholder="Description of class"
             onChange={props.onChange}
             required={!optional}
-            value={props.fields.description || ''}
+            value={props.formFields.description || ''}
           />
         </FormField>
       </fieldset>
@@ -67,29 +74,19 @@ const ClassroomForm = (props) => {
 ClassroomForm.defaultProps = {
   optionalFormFields: true,
   onChange: () => {},
-  fields: {
-    name: '',
-    subject: '',
-    school: '',
-    description: ''
-  },
   heading: '',
   onSubmit: () => {},
-  submitLabel: 'Submit'
+  submitLabel: 'Submit',
+  ...CLASSROOMS_INITIAL_STATE
 };
 
 ClassroomForm.propTypes = {
   optionalFormFields: PropTypes.bool,
   onChange: PropTypes.func,
-  fields: PropTypes.shape({
-    name: PropTypes.string,
-    subject: PropTypes.string,
-    school: PropTypes.string,
-    description: PropTypes.string
-  }),
   heading: PropTypes.string,
   onSubmit: PropTypes.func,
-  submitLabel: PropTypes.string
+  submitLabel: PropTypes.string,
+  ...CLASSROOMS_PROPTYPES
 };
 
 export default ClassroomForm;

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -103,8 +103,8 @@ export class ClassroomEditorContainer extends React.Component {
       const studentHubbleCount = hubbleStudentData[0].attributes.classifications_count;
       const galaxyCountStat = `${studentGalaxyCount}/${galaxyClassificationTarget}`;
       const hubbleCountStat = `${studentHubbleCount}/${hubbleClassificationTarget}`;
-      const galaxyPercentageStat = (studentGalaxyCount / (+galaxyClassificationTarget)) * 100;
-      const hubblePercentageStat = (studentHubbleCount / (+hubbleClassificationTarget)) * 100;
+      const galaxyPercentageStat = Math.round((studentGalaxyCount / (+galaxyClassificationTarget)) * 100);
+      const hubblePercentageStat = Math.round((studentHubbleCount / (+hubbleClassificationTarget)) * 100);
       const row = `"${classroomName}","${studentName}",${galaxyCountStat},${hubbleCountStat},${galaxyPercentageStat},${hubblePercentageStat}\n`;
       csvData += row;
     });

--- a/src/containers/classrooms/ClassroomFormContainer.jsx
+++ b/src/containers/classrooms/ClassroomFormContainer.jsx
@@ -112,8 +112,9 @@ export class ClassroomFormContainer extends React.Component {
   render() {
     return (
       <ClassroomForm
+        classroomsStatus={this.props.classroomsStatus}
         heading={this.props.heading}
-        fields={this.props.formFields}
+        formFields={this.props.formFields}
         onChange={this.onChange}
         onSubmit={this.onSubmit}
         submitLabel={this.props.submitLabel}
@@ -134,6 +135,7 @@ ClassroomFormContainer.propTypes = {
 
 function mapStateToProps(state) {
   return {
+    classroomsStatus: state.classrooms.status,
     formFields: state.classrooms.formFields,
     selectedClassroom: state.classrooms.selectedClassroom,
     selectedProgram: state.programs.selectedProgram

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -56,15 +56,15 @@ const i2a = {
         // used to relate the assignment resource that has a workflow id property
         // back to a project without having to request that from Panoptes
         // to then build the URL to the project in the UI.
-        "1315": {
+        "5522": {
           name: i2aAssignmentNames.hubble,
           classifications_target: "10",
-          slug: 'srallen086/intro2astro-hubble-testing'
+          slug: 'zooniverse/intro2astro-hubbles-law'
         },
-        "1771": {
+        "5521": {
           name: i2aAssignmentNames.galaxy,
           classifications_target: "22",
-          slug: 'srallen086/galaxy-zoo-in-astronomy-101'
+          slug: 'zooniverse/galaxy-zoo-in-astronomy-101'
         }
       }
     }


### PR DESCRIPTION
This is a collection of minor tweaks:

- Updates the percentage stat for assignment completion to use rounded numbers
- Updates the production I2A program mock to correctly reflect what it is on the db
- Consistently uses the formField prop types and prop name with the `ClassroomEditor`
- Uses null for the `ClassroomEditor` form's `onSubmit` if the status is creating. I'm not sure if this totally works yet because production is having random 500s right now, which only happens after a request times out after a few seconds. I want to disable the submit button if there's a pending POST and the Grommet Button is only disabled if the onClick handler is null. I'm not sure if this is true for the handler set for the form on the Form component. We might need to move the event handling to the Button itself?