### PR TITLE
Add button to request new export to failed or no export status message

### DIFF
--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -95,10 +95,15 @@ function ExportModal({
                 </Anchor>.
             </Paragraph>}
           {noExport &&
-            <Paragraph>
-              <Status value="warning" />{' '}
-              No export available for this classroom and assignment.
-            </Paragraph>}
+            <Box>
+              <Paragraph>
+                <Status value="warning" />{' '}
+                No export available for this classroom and assignment or the export failed.
+              </Paragraph>
+              <Paragraph>
+                <Button secondary={true} fill={false} onClick={requestNewExport} label="Request new export" />
+              </Paragraph>
+            </Box>}
           {caesarExport === CAESAR_EXPORTS_INITIAL_STATE.caesarExport &&
             caesarExportStatus === CAESAR_EXPORTS_STATUS.ERROR &&
             <Box>


### PR DESCRIPTION
Pretty much what this says: This adds the button to request another new export if the response is either the failed state or no exports exist from caesar. 