### PR TITLE
Fix all the stats math

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -118,7 +118,10 @@ function AstroClassroomsTable(props) {
                           type="button"
                           className="manager-table__button--as-link"
                           plain={true}
-                          onClick={props.showExportModal.bind(null, assignment, classroom)}
+                          onClick={calculatedCompleteness !== 0 ?
+                            props.showExportModal.bind(null, assignment, classroom) :
+                            null
+                          }
                         >
                           Export Data{' '}
                           <i className="fa fa-arrow-down" aria-hidden="true" />

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -21,12 +21,15 @@ import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
 
-function calculateCompleteness(assignment, classroom) {
+function calculateCompleteness(assignment) {
   const classificationsTarget = +assignment.metadata.classifications_target;
   const numberOfStudents = assignment.studentAssignments.length;
-  const numberOfCompletedClassifications = classroom.classificationsCount;
+  let numberOfCompletedClassificationsPerAssignment;
+  assignment.studentAssignmentsData.forEach((studentAssignment) => {
+    numberOfCompletedClassificationsPerAssignment += studentAssignment.attributes.classifications_count;
+  });
   if (numberOfStudents === 0) return 0;
-  return (Math.round(numberOfCompletedClassifications / (classificationsTarget * numberOfStudents)) * 100);
+  return (Math.round(numberOfCompletedClassificationsPerAssignment / (classificationsTarget * numberOfStudents)) * 100);
 }
 
 function AstroClassroomsTable(props) {
@@ -104,7 +107,7 @@ function AstroClassroomsTable(props) {
                   const projectUrl = (assignmentsMetadata && assignmentsMetadata[assignment.workflowId]) ?
                     `${config.zooniverse}/projects/${assignmentsMetadata[assignment.workflowId].slug}/classify?group=${classroom.attributes.zooniverse_group_id}` :
                     null;
-                  const calculatedCompleteness = calculateCompleteness(assignment, classroom);
+                  const calculatedCompleteness = calculateCompleteness(assignment);
                   return (
                     <TableRow className="manager-table__row-data" key={assignment.id}>
                       <td headers="classroom assignments">{assignment.name}</td>

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -24,12 +24,21 @@ import {
 function calculateCompleteness(assignment) {
   const classificationsTarget = +assignment.metadata.classifications_target;
   const numberOfStudents = assignment.studentAssignments.length;
-  let numberOfCompletedClassificationsPerAssignment;
-  assignment.studentAssignmentsData.forEach((studentAssignment) => {
-    numberOfCompletedClassificationsPerAssignment += studentAssignment.attributes.classifications_count;
-  });
   if (numberOfStudents === 0) return 0;
-  return (Math.round(numberOfCompletedClassificationsPerAssignment / (classificationsTarget * numberOfStudents)) * 100);
+
+  let numberOfCompletedClassificationsPerAssignment = 0;
+  assignment.studentAssignmentsData.forEach((studentAssignment) => {
+    // Just return the classificationsTarget count if the student did more than assigned
+    if (studentAssignment.attributes.classifications_count >= classificationsTarget) {
+      numberOfCompletedClassificationsPerAssignment += classificationsTarget;
+    } else {
+      numberOfCompletedClassificationsPerAssignment += studentAssignment.attributes.classifications_count;
+    }
+  });
+  const totalClassificationsTarget = classificationsTarget * numberOfStudents;
+  const completenessPercentage = ((numberOfCompletedClassificationsPerAssignment / totalClassificationsTarget).toFixed(2) * 100);
+  // Just return 100 if the calculation is over 100.
+  return completenessPercentage <= 100 ? completenessPercentage : 100;
 }
 
 function AstroClassroomsTable(props) {

--- a/src/components/classrooms/ClassroomEditor.jsx
+++ b/src/components/classrooms/ClassroomEditor.jsx
@@ -225,8 +225,8 @@ const ClassroomEditor = (props) => {
                 const hubbleStudentData = hubbleAssignment[0].studentAssignmentsData.filter(
                   data => data.attributes.student_user_id.toString() === student.id);
 
-                const galaxyPercentage = `${Math.round((galaxyStudentData[0].attributes.classifications_count / (+galaxyAssignment[0].metadata.classifications_target)) * 100)}%`;
-                const hubblePercentage = `${Math.round((hubbleStudentData[0].attributes.classifications_count / (+hubbleAssignment[0].metadata.classifications_target)) * 100)}%`;
+                const galaxyPercentage = ((galaxyStudentData[0].attributes.classifications_count / (+galaxyAssignment[0].metadata.classifications_target)).toFixed(2) * 100);
+                const hubblePercentage = ((hubbleStudentData[0].attributes.classifications_count / (+hubbleAssignment[0].metadata.classifications_target)).toFixed(2) * 100);
 
                 const galaxyCount = `${galaxyStudentData[0].attributes.classifications_count} / ${+galaxyAssignment[0].metadata.classifications_target}`;
                 const hubbleCount = `${hubbleStudentData[0].attributes.classifications_count} / ${+hubbleAssignment[0].metadata.classifications_target}`;
@@ -237,8 +237,8 @@ const ClassroomEditor = (props) => {
                       ? <span>{student.zooniverseDisplayName}</span>
                       : <span className="secondary">{student.zooniverseLogin}</span> }
                   </td>
-                  <td headers="assignment-galaxy">{props.showCounts.galaxy ? galaxyCount : galaxyPercentage}</td>
-                  <td headers="assignment-hubble">{props.showCounts.hubble ? hubbleCount : hubblePercentage}</td>
+                  <td headers="assignment-galaxy">{props.showCounts.galaxy ? galaxyCount : `${galaxyPercentage <= 100 ? galaxyPercentage : 100}%`}</td>
+                  <td headers="assignment-hubble">{props.showCounts.hubble ? hubbleCount : `${hubblePercentage <= 100 ? hubblePercentage : 100}%`}</td>
                   <td headers="student-remove">
                     <Button
                       className="manager-table__button--delete"

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -81,9 +81,9 @@ export class ClassroomEditorContainer extends React.Component {
     if (!this.props.selectedClassroom && !this.props.selectedClassroom.students) return null;
     const classroomName = this.props.selectedClassroom.name;
     const galaxyAssignment = this.props.assignments[this.props.selectedClassroom.id].filter(
-      assignment => assignment.name === i2aAssignmentNames.first);
+      assignment => assignment.name === i2aAssignmentNames.galaxy);
     const hubbleAssignment = this.props.assignments[this.props.selectedClassroom.id].filter(
-      assignment => assignment.name === i2aAssignmentNames.second);
+      assignment => assignment.name === i2aAssignmentNames.hubble);
     const galaxyClassificationTarget = galaxyAssignment[0].metadata.classifications_target;
     const hubbleClassificationTarget = hubbleAssignment[0].metadata.classifications_target;
 

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -103,8 +103,8 @@ export class ClassroomEditorContainer extends React.Component {
       const studentHubbleCount = hubbleStudentData[0].attributes.classifications_count;
       const galaxyCountStat = `${studentGalaxyCount}/${galaxyClassificationTarget}`;
       const hubbleCountStat = `${studentHubbleCount}/${hubbleClassificationTarget}`;
-      const galaxyPercentageStat = Math.round((studentGalaxyCount / (+galaxyClassificationTarget)) * 100);
-      const hubblePercentageStat = Math.round((studentHubbleCount / (+hubbleClassificationTarget)) * 100);
+      const galaxyPercentageStat = ((studentGalaxyCount / (+galaxyClassificationTarget)).toFixed(2) * 100);
+      const hubblePercentageStat = ((studentHubbleCount / (+hubbleClassificationTarget)).toFixed(2) * 100);
       const row = `"${classroomName}","${studentName}",${galaxyCountStat},${hubbleCountStat},${galaxyPercentageStat},${hubblePercentageStat}\n`;
       csvData += row;
     });

--- a/src/containers/classrooms/ClassroomEditorContainer.jsx
+++ b/src/containers/classrooms/ClassroomEditorContainer.jsx
@@ -105,7 +105,7 @@ export class ClassroomEditorContainer extends React.Component {
       const hubbleCountStat = `${studentHubbleCount}/${hubbleClassificationTarget}`;
       const galaxyPercentageStat = ((studentGalaxyCount / (+galaxyClassificationTarget)).toFixed(2) * 100);
       const hubblePercentageStat = ((studentHubbleCount / (+hubbleClassificationTarget)).toFixed(2) * 100);
-      const row = `"${classroomName}","${studentName}",${galaxyCountStat},${hubbleCountStat},${galaxyPercentageStat},${hubblePercentageStat}\n`;
+      const row = `"${classroomName}","${studentName}",${galaxyCountStat},${hubbleCountStat},${galaxyPercentageStat <= 100 ? galaxyPercentageStat : 100},${hubblePercentageStat <= 100 ? hubblePercentageStat : 100}\n`;
       csvData += row;
     });
     saveAs(blobbifyData(csvData, 'text/csv'), generateFilename('astro101-', '.csv'));


### PR DESCRIPTION
Closes #100 and fixes a bunch of stats math I did wrong. 

- When you want to round to two decimal places, you use `toFixed()` not `Math.round()` 🤦‍♀️ 
- Fixes percentages on the classrooms table view. I was using the classroom's classification count instead of the sum of the individual student's assignment's counts.
- Just display 100% even if the student does more classifications than assigned
- Fixes a regression with the Export stats button
- Disables the Export Data button if there are no classifications (#100)

How to test manually:

I had to already deploy this branch to production because the lambdas to do the counts on staging isn't setup. This should be ok because no one is really using the production site yet.

- Log in as zootester1
- You should see an I2A classroom "A classroom with no classifications" with no classifications yet and the Export Data buttons disabled
- Classroom "Test classroom 7 Dec 2017" has two students that have done various numbers of classifications per assignment. The percentage should be from the total classifications per student / total number of classifications based on the number of students assigned. Galaxy's is 10  / 44 or 23%. Hubble's is 60% or 12 / 20.
- If you go to the classroom edit page, you should see the correct percentages per student. If you toggle between the percentage and fractional views, then you can confirm the numbers 10 / 44 and 12 / 20 by summing them. 
- You will see zootester2 did 12 / 10 classifications for Hubble's Law. Teacher's won't care that the student did too many classifications, just that they completed the assignment, so this gets reported as 100% and the extra classifications aren't used in the overall stat calculation.
