### PR TITLE
Darien Classrooms & Assignments Mk2 - Part 2

### DIFF
--- a/src/components/common/Status401.jsx
+++ b/src/components/common/Status401.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import GenericStatusPage from './GenericStatusPage';
 
-function Darien401(props) {
+function Status401(props) {
   return (
     <GenericStatusPage status="warning" message="Please login to view this page." />
   );
 };
 
-export default Darien401;
+export default Status401;

--- a/src/components/common/Status404.jsx
+++ b/src/components/common/Status404.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import GenericStatusPage from './GenericStatusPage';
 
-function Darien404(props) {
+function Status404(props) {
   return (
     <GenericStatusPage status="warning" message="Page not found." />
   );
 };
 
-export default Darien404;
+export default Status404;

--- a/src/components/darien/DarienEducators.jsx
+++ b/src/components/darien/DarienEducators.jsx
@@ -1,14 +1,53 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import ClassroomsLayout from '../classrooms/ClassroomsLayout';
+import { connect } from 'react-redux';
+import { Redirect, Route, Switch } from 'react-router-dom';
+import { Actions } from 'jumpstate';
+import Box from 'grommet/components/Box';
+import Toast from 'grommet/components/Toast';
 
-function DarienEducators(props) {
+import ClassroomsManagerContainer from '../../containers/classrooms/ClassroomsManagerContainer';
+import ClassroomEditorContainer from '../../containers/classrooms/ClassroomEditorContainer';
+
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+
+function DarienEducators({ classroomInstructions, match, toast }) {
   return (
-    <ClassroomsLayout match={props.match} />
+    <Box
+      className="classrooms-layout"
+      direction="column"
+      colorIndex="grey-5"
+      full={{ horizontal: true, vertical: false }}
+      pad="large"
+    >
+      {toast && toast.message &&
+        <Toast
+          status={toast.status ? toast.status : 'unknown'}
+          onClose={() => { Actions.classrooms.setToastState({ status: null, message: null }); }}
+        >
+          {toast.message}
+        </Toast>}
+      <Switch>
+        <Route exact path={`${match.url}/classrooms/:id`} component={ClassroomEditorContainer} />
+        <Route path={`${match.url}`} component={ClassroomsManagerContainer} classroomInstructions={classroomInstructions} />
+      </Switch>
+    </Box>
   );
 };
 
-DarienEducators.defaultProps = {};
-DarienEducators.propTypes = {};
+DarienEducators.defaultProps = {
+  ...CLASSROOMS_INITIAL_STATE
+};
 
-export default DarienEducators;
+DarienEducators.propTypes = {
+  ...CLASSROOMS_PROPTYPES
+};
+
+function mapStateToProps(state) {
+  return {
+    toast: state.classrooms.toast
+  };
+}
+
+export default connect(mapStateToProps)(DarienEducators);

--- a/src/components/wildcam-classrooms/WildCamClassroomEditor.jsx
+++ b/src/components/wildcam-classrooms/WildCamClassroomEditor.jsx
@@ -1,0 +1,266 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Actions } from 'jumpstate';
+
+import Anchor from 'grommet/components/Anchor';
+import Box from 'grommet/components/Box';
+import Button from 'grommet/components/Button';
+import Heading from 'grommet/components/Heading';
+import Label from 'grommet/components/Label';
+import Layer from 'grommet/components/Layer';
+import List from 'grommet/components/List';
+import ListItem from 'grommet/components/ListItem';
+import Paragraph from 'grommet/components/Paragraph';
+import Table from 'grommet/components/Table';
+import TableRow from 'grommet/components/TableRow';
+
+import CloseIcon from 'grommet/components/icons/base/Close';
+import EditIcon from 'grommet/components/icons/base/Edit';
+import Spinning from 'grommet/components/icons/Spinning';
+import LinkPreviousIcon from 'grommet/components/icons/base/LinkPrevious';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import WildCamClassroomFormContainer from '../../containers/wildcam-classrooms/WildCamClassroomFormContainer';
+import ConfirmationDialog from '../common/ConfirmationDialog';
+
+import {
+  CLASSROOMS_STATUS, CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+import {
+  ASSIGNMENTS_STATUS
+} from '../../ducks/assignments';
+import { config } from '../../lib/config';
+
+const WildCamClassroomEditor = (props) => {
+  const joinURL = props.selectedClassroom ?
+    `${config.origin}/#/${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}` :
+    '';
+
+  // Get students and assignments only for this classroom.
+  const students = (props.selectedClassroom && props.selectedClassroom.students) ? props.selectedClassroom.students : [];
+  const assignments = (props.selectedClassroom && props.assignments && props.assignments[props.selectedClassroom.id])
+    ? props.assignments[props.selectedClassroom.id]
+    : [];
+
+  const programURL = props.match.url.split('/'); // Remove once programs is in place with API
+
+  if (!props.selectedClassroom && props.classroomsStatus === CLASSROOMS_STATUS.FETCHING) {
+    return (
+      <Box align="center" className="classroom-editor"><Spinning /></Box>
+    );
+  }
+
+  if (!props.selectedClassroom && props.classroomsStatus === CLASSROOMS_STATUS.ERROR) {
+    return (
+      <Box className="classroom-editor" direction="column" colorIndex="light-1">
+        <Box pad="small">
+          <Anchor
+            path={`/${programURL[1]}/educators`}
+            icon={<LinkPreviousIcon size="small" />}
+            label="Back to Classroom List"
+            className="summary__return-link"
+          />
+        </Box>
+        <Box pad="small">
+          <Paragraph>Error: Classroom could not be loaded</Paragraph>
+        </Box>
+      </Box>
+    );
+  }
+
+
+  if (props.selectedClassroom && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) {
+    return (
+      <Box
+        className="classroom-editor"
+        direction="column"
+      >
+        <ConfirmationDialog
+          confirmationButtonLabel="Remove"
+          onConfirmation={props.removeStudentFromClassroom}
+          onClose={props.closeConfirmationDialog}
+          showConfirmationDialog={props.showConfirmationDialog}
+        >
+          <Paragraph size="small">This will remove the student record and their progress from the classroom.</Paragraph>
+        </ConfirmationDialog>
+
+        {props.showForm &&
+          <Layer closer={true} onClose={props.toggleFormVisibility}>
+            <WildCamClassroomFormContainer heading="Edit Classroom" submitLabel="Update" />
+          </Layer>}
+
+        <Box
+          align="center"
+          direction="row"
+          justify="between"
+          pad="small"
+        >
+          <Box flex={true}>
+            <Paragraph align="start" size="small">Click an assignment column to toggle between percentages and number of classifications.</Paragraph>
+          </Box>
+
+          <CopyToClipboard
+            className="join-link__button"
+            text={joinURL}
+            onCopy={() => { Actions.classrooms.setToastState({ status: 'ok', message: 'Copied join link.' }); }}
+          >
+            <Button type="button" label="Copy Join Link" />
+          </CopyToClipboard>
+
+          <Button
+            className="button--primary"
+            type="button"
+            primary={true}
+            label="Export Stats"
+            onClick={props.selectedClassroom && props.selectedClassroom.students.length > 0 ? props.exportStats : null}
+          />
+        </Box>
+
+        <Box
+          className="manager-summary"
+          pad="small"
+        >
+          <Box pad="small">
+            <Anchor
+              path={`/${programURL[1]}/educators`}
+              icon={<LinkPreviousIcon size="small" />}
+              label="Back to Classroom List"
+              className="summary__return-link"
+            />
+          </Box>
+          <Box direction="row">
+            <Button
+              className="manager-table__button--edit"
+              type="button"
+              onClick={props.editClassroom}
+              icon={<EditIcon size="small" />}
+            />
+            <Heading tag="h2" strong={true}>{props.selectedClassroom.name}</Heading>
+          </Box>
+          <List>
+            {(!(props.selectedClassroom.subject && props.selectedClassroom.subject.length > 0)) ? null :
+              <ListItem>
+                <Label className="secondary">Subject</Label>
+                <span>{props.selectedClassroom.subject}</span>
+              </ListItem>
+            }
+            {(!(props.selectedClassroom.school && props.selectedClassroom.school.length > 0)) ? null :
+              <ListItem>
+                <Label className="secondary">Institution</Label>
+                <span>{props.selectedClassroom.school}</span>
+              </ListItem>
+            }
+            {(!(props.selectedClassroom.description && props.selectedClassroom.description.length > 0)) ? null :
+              <ListItem>
+                <Label className="secondary">Description</Label>
+                <span>{props.selectedClassroom.description}</span>
+              </ListItem>
+            }
+            <ListItem>
+              <Label className="secondary">Join Link</Label>
+              <span>{joinURL}</span>
+            </ListItem>
+          </List>
+        </Box>
+
+        <Table className="manager-table">
+          <thead className="manager-table__headers">
+            <TableRow>
+              <th id="student-name" scope="col">
+                <span className="headers__header">Student Name/Zooniverse ID</span>
+              </th>
+              <th id="assignment-galaxy" scope="col">
+                ABC
+              </th>
+              <th id="assignment-hubble" scope="col" >
+                ABC
+              </th>
+              <th id="student-remove" scope="col">
+                <span className="headers__header">Remove Student</span>
+              </th>
+            </TableRow>
+          </thead>
+
+          <tbody className="manager-table__body">
+            {props.assignmentsStatus === ASSIGNMENTS_STATUS.FETCHING && (
+              <TableRow className="manager-table__row-data">
+                <td colSpan="4"><Spinning /></td>
+              </TableRow>
+            )}
+
+            {props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS &&
+            assignments &&
+            assignments.length > 0 &&
+            students.length === 0 && (
+              <TableRow className="manager-table__row-data">
+                <td colSpan="4"><Paragraph>No students have joined yet.</Paragraph></td>
+              </TableRow>
+            )}
+
+            {props.assignmentsStatus === ASSIGNMENTS_STATUS.SUCCESS &&
+            assignments &&
+            assignments.length > 0 &&
+            students.length > 0 &&
+              students.map((student) => { return (
+                <TableRow className="manager-table__row-data" key={`classroom-student-${student.id}`}>
+                  <td headers="student-name">
+                    {(student.zooniverseDisplayName && student.zooniverseDisplayName.length > 0)
+                      ? <span>{student.zooniverseDisplayName}</span>
+                      : <span className="secondary">{student.zooniverseLogin}</span> }
+                  </td>
+                  <td headers="assignment-galaxy">ABC</td>
+                  <td headers="assignment-hubble">ABC</td>
+                  <td headers="student-remove">
+                    <Button
+                      className="manager-table__button--delete"
+                      type="button"
+                      onClick={props.maybeRemoveStudentFromClassroom.bind(null, props.selectedClassroom.id, student.id)}
+                      icon={<CloseIcon size="small" />}
+                    />
+                  </td>
+                </TableRow>);
+              })}
+          </tbody>
+
+        </Table>
+      </Box>
+    );
+  }
+
+  return null;
+};
+
+WildCamClassroomEditor.defaultProps = {
+  editClassroom: () => {},
+  exportStats: () => {},
+  selectClassroom: () => {},
+  removeStudentFromClassroom: () => {},
+  //----------------
+  showConfirmationDialog: false,
+  showCounts: {
+    galaxy: false,
+    hubble: false
+  },
+  showForm: false,
+  toggleFormVisibility: Actions.classrooms.toggleFormVisibility,
+  //----------------
+  ...CLASSROOMS_INITIAL_STATE
+};
+
+WildCamClassroomEditor.propTypes = {
+  editClassroom: PropTypes.func,
+  exportStats: PropTypes.func,
+  selectClassroom: PropTypes.func,
+  removeStudentFromClassroom: PropTypes.func,
+  //----------------
+  showConfirmationDialog: PropTypes.bool,
+  showCounts: PropTypes.shape({
+    galaxy: PropTypes.bool,
+    hubble: PropTypes.bool
+  }),
+  showForm: PropTypes.bool,
+  toggleFormVisibility: PropTypes.func,
+  //----------------
+  ...CLASSROOMS_PROPTYPES
+};
+
+export default WildCamClassroomEditor;

--- a/src/components/wildcam-classrooms/WildCamClassroomForm.jsx
+++ b/src/components/wildcam-classrooms/WildCamClassroomForm.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Form from 'grommet/components/Form';
+import FormField from 'grommet/components/FormField';
+import TextInput from 'grommet/components/TextInput';
+import Button from 'grommet/components/Button';
+import Heading from 'grommet/components/Heading';
+import Footer from 'grommet/components/Footer';
+import Paragraph from 'grommet/components/Paragraph';
+
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES, CLASSROOMS_STATUS
+} from '../../ducks/classrooms';
+
+function WildCamClassroomForm(props) {
+  const optional = props.optionalFormFields;
+  return (
+    <Form
+      onSubmit={props.classroomsStatus === CLASSROOMS_STATUS.CREATING ? null : props.onSubmit}
+      pad="medium"
+    >
+      <Heading tag="h2">{props.heading}</Heading>
+      <fieldset>
+        <legend><Paragraph size="small">Input the class name and if applicable the section name</Paragraph></legend>
+        <FormField htmlFor="name" label="Name" help="required">
+          <TextInput
+            id="name"
+            placeHolder="Class name"
+            onDOMChange={props.onChange}
+            required={true}
+            value={props.formFields.name}
+          />
+        </FormField>
+      </fieldset>
+
+      <fieldset>
+        {optional &&
+          <legend><Paragraph size="small">Optional - Please fill out for Zooniverse to better understand who is using our education tools</Paragraph></legend>}
+        <FormField htmlFor="subject" label="Subject">
+          <TextInput
+            id="subject"
+            placeHolder="Class subject"
+            onDOMChange={props.onChange}
+            required={!optional}
+            value={props.formFields.subject || ''}
+          />
+        </FormField>
+        <FormField htmlFor="school" label="Institution">
+          <TextInput
+            id="school"
+            placeHolder="Name of institution or school"
+            onDOMChange={props.onChange}
+            required={!optional}
+            value={props.formFields.school || ''}
+          />
+        </FormField>
+        <FormField htmlFor="description" label="Description">
+          <textarea
+            id="description"
+            placeholder="Description of class"
+            onChange={props.onChange}
+            required={!optional}
+            value={props.formFields.description || ''}
+          />
+        </FormField>
+      </fieldset>
+      <Footer>
+        <Button className="button--primary" type="submit" label={props.submitLabel} primary={true} />
+      </Footer>
+    </Form>
+  );
+};
+
+WildCamClassroomForm.defaultProps = {
+  optionalFormFields: true,
+  onChange: () => {},
+  heading: '',
+  onSubmit: () => {},
+  submitLabel: 'Submit',
+  ...CLASSROOMS_INITIAL_STATE
+};
+
+WildCamClassroomForm.propTypes = {
+  optionalFormFields: PropTypes.bool,
+  onChange: PropTypes.func,
+  heading: PropTypes.string,
+  onSubmit: PropTypes.func,
+  submitLabel: PropTypes.string,
+  ...CLASSROOMS_PROPTYPES
+};
+
+export default WildCamClassroomForm;

--- a/src/components/wildcam-classrooms/WildCamClassroomsLayout.jsx
+++ b/src/components/wildcam-classrooms/WildCamClassroomsLayout.jsx
@@ -12,7 +12,7 @@ import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
 
-function DarienEducators({ classroomInstructions, match, toast }) {
+const ClassroomsLayout = ({ classroomInstructions, match, toast }) => {
   return (
     <Box
       className="classrooms-layout"
@@ -36,11 +36,11 @@ function DarienEducators({ classroomInstructions, match, toast }) {
   );
 };
 
-DarienEducators.defaultProps = {
+ClassroomsLayout.defaultProps = {
   ...CLASSROOMS_INITIAL_STATE
 };
 
-DarienEducators.propTypes = {
+ClassroomsLayout.propTypes = {
   ...CLASSROOMS_PROPTYPES
 };
 
@@ -50,4 +50,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(DarienEducators);
+export default connect(mapStateToProps)(ClassroomsLayout);

--- a/src/components/wildcam-classrooms/WildCamClassroomsManager.jsx
+++ b/src/components/wildcam-classrooms/WildCamClassroomsManager.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Actions } from 'jumpstate';
+import { Link } from 'react-router-dom';
+import Box from 'grommet/components/Box';
+import Paragraph from 'grommet/components/Paragraph';
+import Button from 'grommet/components/Button';
+import Spinning from 'grommet/components/icons/Spinning';
+import Layer from 'grommet/components/Layer';
+
+import {
+  CLASSROOMS_STATUS, CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+
+import WildCamClassroomFormContainer from '../../containers/wildcam-classrooms/WildCamClassroomFormContainer';
+import WildCamClassroomsTableContainer from '../../containers/wildcam-classrooms/WildCamClassroomsTableContainer';
+
+const WildCamClassroomsManager = (props) => {
+  // TODO: Pagination for Classrooms
+  return (
+    <Box className="classrooms-manager">
+      <Box className="classrooms-manager__instructions" align="center" direction="row" justify="between" size="xxlarge">
+        <Paragraph align="start" size="small">{props.classroomInstructions}</Paragraph>
+        <Button
+          className="button--primary"
+          type="button"
+          primary={true}
+          label="Create New Classroom"
+          onClick={props.toggleFormVisibility}
+        />
+      </Box>
+      {props.showForm &&
+        <Layer closer={true} onClose={props.toggleFormVisibility}>
+          <WildCamClassroomFormContainer heading="Create Classroom" submitLabel="Create" />
+        </Layer>}
+      {(props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.FETCHING) &&
+        <Box align="center"><Spinning /></Box>}
+      {props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS &&
+        <Paragraph>No classrooms have been created yet.</Paragraph>}
+      {props.classrooms.length === 0 && props.classroomsStatus === CLASSROOMS_STATUS.ERROR &&
+        <Paragraph>Error: Classrooms could not be loaded.</Paragraph>}
+      {(props.classrooms.length > 0 && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) &&
+        <WildCamClassroomsTableContainer match={props.match} />}
+    </Box>
+  );
+};
+
+WildCamClassroomsManager.defaultProps = {
+  classroomInstructions: 'First, make sure your students have set up a Zooniverse account. Then create a classroom and share the classroom\'s unique join URL with your students to keep track of their progress as they work through each assignment. Students must be logged in to their Zooniverse accounts first to be able to use the join link. Share the URL under View Project with your students for them to complete the assignment.',
+  showForm: false,
+  toggleFormVisibility: Actions.classrooms.toggleFormVisibility,
+  ...CLASSROOMS_INITIAL_STATE
+};
+
+WildCamClassroomsManager.propTypes = {
+  classroomInstructions: PropTypes.string,
+  showForm: PropTypes.bool,
+  toggleFormVisibility: PropTypes.func,
+  ...CLASSROOMS_PROPTYPES
+};
+
+export default WildCamClassroomsManager;

--- a/src/components/wildcam-classrooms/WildCamClassroomsTable.jsx
+++ b/src/components/wildcam-classrooms/WildCamClassroomsTable.jsx
@@ -22,7 +22,7 @@ import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
 } from '../../ducks/classrooms';
 
-function DarienClassroomsTable(props) {
+function WildCamClassroomsTable(props) {
   return (
     <Box>
       {props.children}
@@ -128,7 +128,7 @@ function DarienClassroomsTable(props) {
                       <td headers="classroom view-project">
                         <Anchor
                           className="manager-table__link"
-                          href={`${config.zooniverse}/projects/wildcam/wildcam-darien/classify?workflow=${assignment.workflow_id}`}
+                          href={`${config.zooniverse}/projects/wildcam/wildcam-darien/classify?workflow=${assignment.workflow_id}` /*TODO: Adapt for WildCam Gorongosa */}
                           target="_blank"
                           rel="noopener noreferrer"
                         >
@@ -154,7 +154,7 @@ function DarienClassroomsTable(props) {
   );
 };
 
-DarienClassroomsTable.defaultProps = {
+WildCamClassroomsTable.defaultProps = {
   closeConfirmationDialog: () => {},
   maybeDeleteAssignment: () => {},
   maybeDeleteClassroom: () => {},
@@ -163,7 +163,7 @@ DarienClassroomsTable.defaultProps = {
   ...ASSIGNMENTS_INITIAL_STATE
 };
 
-DarienClassroomsTable.propTypes = {
+WildCamClassroomsTable.propTypes = {
   closeConfirmationDialog: PropTypes.func,
   maybeDeleteAssignment: PropTypes.func,
   maybeDeleteClassroom: PropTypes.func,
@@ -172,4 +172,4 @@ DarienClassroomsTable.propTypes = {
   ...ASSIGNMENTS_PROPTYPES
 };
 
-export default DarienClassroomsTable;
+export default WildCamClassroomsTable;

--- a/src/containers/wildcam-classrooms/WildCamClassroomEditorContainer.jsx
+++ b/src/containers/wildcam-classrooms/WildCamClassroomEditorContainer.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
+import { saveAs } from 'browser-filesaver';
+import WildCamClassroomEditor from '../../components/wildcam-classrooms/WildCamClassroomEditor';
+import { blobbifyData, generateFilename } from '../../lib/file-download-helpers';
+
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+import {
+  ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
+} from '../../ducks/assignments';
+import {
+  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES, i2aAssignmentNames
+} from '../../ducks/programs';
+
+export class WildCamClassroomEditorContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showConfirmationDialog: false,
+      studentToDelete: {
+        classroomId: null,
+        studentId: null
+      }
+    };
+
+    this.closeConfirmationDialog = this.closeConfirmationDialog.bind(this);
+    this.editClassroom = this.editClassroom.bind(this);
+    this.exportStats = this.exportStats.bind(this);
+    this.maybeRemoveStudentFromClassroom = this.maybeRemoveStudentFromClassroom.bind(this);
+    this.removeStudentFromClassroom = this.removeStudentFromClassroom.bind(this);
+  }
+
+  componentDidMount() {
+    if (this.props.selectedProgram && !this.props.selectedClassroom) {
+      this.getClassroomAndAssignments(this.props);
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.selectedProgram &&
+        this.props.selectedProgram !== nextProps.selectedProgram &&
+        !this.props.selectedClassroom) {
+      this.getClassroomAndAssignments(nextProps);
+    }
+  }
+
+  componentWillUnmount() {
+    Actions.classrooms.selectClassroom(CLASSROOMS_INITIAL_STATE.selectedClassroom);
+  }
+
+  getClassroomAndAssignments(props) {
+    Actions.getClassroom(props.match.params.id)
+      .then(classroom => Actions.getAssignments({ classroomId: classroom.id, selectedProgram: props.selectedProgram }));
+  }
+
+  editClassroom() {
+    if (this.props.selectedClassroom) {
+      const formFields = {
+        name: this.props.selectedClassroom.name,
+        subject: this.props.selectedClassroom.subject,
+        school: this.props.selectedClassroom.school,
+        description: this.props.selectedClassroom.description
+      };
+      Actions.classrooms.updateFormFields(formFields);
+      Actions.classrooms.toggleFormVisibility();
+    }
+
+    return null;
+  }
+
+  exportStats() {
+    //TODO
+  }
+
+  maybeRemoveStudentFromClassroom(classroomId, studentId) {
+    this.setState({ studentToDelete: { classroomId, studentId }, showConfirmationDialog: true });
+  }
+
+  closeConfirmationDialog() {
+    this.setState({ studentToDelete: null, showConfirmationDialog: false });
+  }
+
+  removeStudentFromClassroom() {
+    if (this.state.studentToDelete === null) return;
+
+    Actions.removeStudentFromClassroom(this.state.studentToDelete).then((response) => {
+      Actions.getClassroom(this.props.match.params.id);
+      this.closeConfirmationDialog();
+
+      if (response) {
+        Actions.classrooms.setToastState({ status: 'ok', message: 'Student removed' });
+      }
+    });
+  }
+
+  render() {
+    return (
+      <WildCamClassroomEditor
+        assignments={this.props.assignments}
+        assignmentsStatus={this.props.assignmentsStatus}
+        classroomsStatus={this.props.classroomsStatus}
+        closeConfirmationDialog={this.closeConfirmationDialog}
+        editClassroom={this.editClassroom}
+        exportStats={this.exportStats}
+        match={this.props.match}
+        maybeRemoveStudentFromClassroom={this.maybeRemoveStudentFromClassroom}
+        removeStudentFromClassroom={this.removeStudentFromClassroom}
+        selectedClassroom={this.props.selectedClassroom}
+        selectedProgram={this.props.selectedProgram}
+        showConfirmationDialog={this.state.showConfirmationDialog}
+        showForm={this.props.showForm}
+      />
+    );
+  }
+}
+
+WildCamClassroomEditorContainer.propTypes = {
+  ...ASSIGNMENTS_PROPTYPES,
+  ...CLASSROOMS_PROPTYPES,
+  ...PROGRAMS_PROPTYPES
+};
+
+WildCamClassroomEditorContainer.defaultProps = {
+  ...ASSIGNMENTS_INITIAL_STATE,
+  ...CLASSROOMS_INITIAL_STATE,
+  ...PROGRAMS_INITIAL_STATE
+};
+
+const mapStateToProps = (state) => ({
+  assignments: state.assignments.assignments,
+  assignmentsStatus: state.assignments.status,
+  classrooms: state.classrooms.classrooms,
+  classroomsStatus: state.classrooms.status,
+  programs: state.programs.programs,
+  selectedClassroom: state.classrooms.selectedClassroom,
+  selectedProgram: state.programs.selectedProgram,
+  showForm: state.classrooms.showForm
+});
+
+export default connect(mapStateToProps)(WildCamClassroomEditorContainer);

--- a/src/containers/wildcam-classrooms/WildCamClassroomFormContainer.jsx
+++ b/src/containers/wildcam-classrooms/WildCamClassroomFormContainer.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
+
+import WildCamClassroomForm from '../../components/wildcam-classrooms/WildCamClassroomForm';
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+import {
+  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
+} from '../../ducks/programs';
+
+export class WildCamClassroomFormContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.autoCreateAssignments = this.autoCreateAssignments.bind(this);
+    this.createClassroom = this.createClassroom.bind(this);
+    this.onChange = this.onChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+    this.closeForm = this.closeForm.bind(this);
+    this.updateClassroom = this.updateClassroom.bind(this);
+  }
+
+  componentWillUnmount() {
+    this.resetFormFields();
+  }
+
+  onChange(event) {
+    const fields = { ...this.props.formFields, [event.target.id]: event.target.value };
+    Actions.classrooms.updateFormFields(fields);
+  }
+
+  onSubmit(event) {
+    event.preventDefault();
+    if (this.props.selectedClassroom) {
+      this.updateClassroom().then(() => {
+        Actions.getClassroom(this.props.selectedClassroom.id);
+        this.closeForm();
+      });
+    } else {
+      this.createClassroom().then(() => {
+        Actions.getClassroomsAndAssignments(this.props.selectedProgram);
+        this.closeForm();
+      });
+    }
+  }
+
+  resetFormFields() {
+    Actions.classrooms.updateFormFields(CLASSROOMS_INITIAL_STATE.formFields);
+  }
+
+  closeForm() {
+    Actions.classrooms.toggleFormVisibility();
+  }
+
+  createClassroom() {
+    const classroomData = {
+      attributes: this.props.formFields,
+      relationships: {
+        program: {
+          data: {
+            id: this.props.selectedProgram.id,
+            type: 'programs'
+          }
+        }
+      }
+    };
+
+    return Actions.createClassroom(classroomData)
+      .then((classroom) => {
+        if (!this.props.selectedProgram.custom) {
+          const assignments = this.props.selectedProgram.metadata.assignments;
+          if (classroom) this.autoCreateAssignments(assignments, classroom);
+        }
+      });
+  }
+
+  updateClassroom() {
+    return Actions.updateClassroom({ id: this.props.selectedClassroom.id, payload: this.props.formFields });
+  }
+
+  autoCreateAssignments(assignments, classroom) {
+    Promise.resolve(Object.keys(assignments).forEach((workflowId) => {
+      // The classroom creation action won't have any students yet.
+      // How do I later associate these auto-created assignments with the new classroom
+      // with students who join later?
+      // Might have to include assigning the student to the assignments for I2A classrooms
+      // on the join classroom action.
+      const assignmentData = {
+        attributes: {
+          name: assignments[workflowId].name,
+          metadata: {
+            classifications_target: assignments[workflowId].classifications_target
+          },
+          workflow_id: workflowId
+        },
+        relationships: {
+          classroom: {
+            data: {
+              id: classroom.id,
+              type: 'classrooms'
+            }
+          }
+        }
+      };
+
+      Actions.createAssignment(assignmentData);
+    }));
+  }
+
+  render() {
+    return (
+      <WildCamClassroomForm
+        classroomsStatus={this.props.classroomsStatus}
+        heading={this.props.heading}
+        formFields={this.props.formFields}
+        onChange={this.onChange}
+        onSubmit={this.onSubmit}
+        submitLabel={this.props.submitLabel}
+      />
+    );
+  }
+}
+
+WildCamClassroomFormContainer.defaultProps = {
+  ...PROGRAMS_INITIAL_STATE,
+  ...CLASSROOMS_INITIAL_STATE
+};
+
+WildCamClassroomFormContainer.propTypes = {
+  ...PROGRAMS_PROPTYPES,
+  ...CLASSROOMS_PROPTYPES
+};
+
+function mapStateToProps(state) {
+  return {
+    classroomsStatus: state.classrooms.status,
+    formFields: state.classrooms.formFields,
+    selectedClassroom: state.classrooms.selectedClassroom,
+    selectedProgram: state.programs.selectedProgram
+  };
+}
+
+export default connect(mapStateToProps)(WildCamClassroomFormContainer);

--- a/src/containers/wildcam-classrooms/WildCamClassroomsManagerContainer.jsx
+++ b/src/containers/wildcam-classrooms/WildCamClassroomsManagerContainer.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
+import WildCamClassroomsManager from '../../components/wildcam-classrooms/WildCamClassroomsManager';
+
+import {
+  CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
+} from '../../ducks/classrooms';
+import {
+  PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES
+} from '../../ducks/programs';
+
+export class WildCamClassroomsManagerContainer extends React.Component {
+  componentDidMount() {
+    if (this.props.selectedProgram) Actions.getClassroomsAndAssignments(this.props.selectedProgram);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.selectedProgram && this.props.selectedProgram !== nextProps.selectedProgram) {
+      Actions.getClassroomsAndAssignments(nextProps.selectedProgram);
+    }
+  }
+
+  componentWillUnmount() {
+    Actions.classrooms.setClassrooms(CLASSROOMS_INITIAL_STATE.classrooms);
+  }
+
+  render() {
+    return (
+      <WildCamClassroomsManager
+        classrooms={this.props.classrooms}
+        classroomInstructions={this.props.classroomInstructions}
+        classroomsStatus={this.props.classroomsStatus}
+        match={this.props.match}
+        showForm={this.props.showForm}
+      />
+    );
+  }
+}
+
+WildCamClassroomsManagerContainer.propTypes = {
+  ...CLASSROOMS_PROPTYPES,
+  ...PROGRAMS_PROPTYPES
+};
+
+WildCamClassroomsManagerContainer.defaultProps = {
+  ...CLASSROOMS_INITIAL_STATE,
+  ...PROGRAMS_INITIAL_STATE
+};
+
+const mapStateToProps = (state) => ({
+  classrooms: state.classrooms.classrooms,
+  classroomsStatus: state.classrooms.status,
+  programs: state.programs.programs,
+  selectedClassroom: state.classrooms.selectedClassroom,
+  selectedProgram: state.programs.selectedProgram,
+  showForm: state.classrooms.showForm
+});
+
+export default connect(mapStateToProps)(WildCamClassroomsManagerContainer);

--- a/src/containers/wildcam-classrooms/WildCamClassroomsTableContainer.jsx
+++ b/src/containers/wildcam-classrooms/WildCamClassroomsTableContainer.jsx
@@ -5,7 +5,7 @@ import Paragraph from 'grommet/components/Paragraph';
 
 import ConfirmationDialog from '../../components/common/ConfirmationDialog';
 import AssignmentFormDialog from '../assignments/AssignmentFormDialog';
-import AstroClassroomsTableContainer from '../astro/AstroClassroomsTableContainer';
+import WildCamClassroomsTable from '../../components/wildcam-classrooms/WildCamClassroomsTable';
 
 import {
   CLASSROOMS_INITIAL_STATE, CLASSROOMS_PROPTYPES
@@ -14,7 +14,7 @@ import {
   ASSIGNMENTS_INITIAL_STATE, ASSIGNMENTS_PROPTYPES
 } from '../../ducks/assignments';
 
-class ClassroomsTableContainer extends React.Component {
+class WildCamClassroomsTableContainer extends React.Component {
   constructor() {
     super();
 
@@ -95,10 +95,9 @@ class ClassroomsTableContainer extends React.Component {
     });
   }
 
-  determineClassroomsTable() {
-    const ClassroomsTable = AstroClassroomsTableContainer;
+  render() {
     return (
-      <ClassroomsTable
+      <WildCamClassroomsTable
         assignments={this.props.assignments}
         assignmentsStatus={this.props.assignmentsStatus}
         classrooms={this.props.classrooms}
@@ -124,21 +123,17 @@ class ClassroomsTableContainer extends React.Component {
         >
           <Paragraph size="small">Deleting a classroom will also delete the associated assignments.</Paragraph>
         </ConfirmationDialog>
-      </ClassroomsTable>
+      </WildCamClassroomsTable>
     );
-  }
-
-  render() {
-    return (this.determineClassroomsTable());
   }
 }
 
-ClassroomsTableContainer.defaultProps = {
+WildCamClassroomsTableContainer.defaultProps = {
   ...ASSIGNMENTS_INITIAL_STATE,
   ...CLASSROOMS_INITIAL_STATE
 };
 
-ClassroomsTableContainer.propTypes = {
+WildCamClassroomsTableContainer.propTypes = {
   ...ASSIGNMENTS_PROPTYPES,
   ...CLASSROOMS_PROPTYPES
 };
@@ -152,5 +147,5 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(ClassroomsTableContainer);
+export default connect(mapStateToProps)(WildCamClassroomsTableContainer);
 


### PR DESCRIPTION
## PR Overview
This PR plans to improve the WildCam Darien Lab's Classrooms and Assignments systems, following up from Part 1 in #107 . I have an eye on making a generalised 'WildCam' Classroom & Assignment system (as opposed to being Darien-specific) but we'll see how that generalisation goes.

Goals:
- [x] Educators can create & edit Darien-specific Classrooms.
- [x] Educators can create & edit Darien-specific Assignments.
- [ ] [major] Educators can select Subjects from the Map Explorer to create Assignments.
- [ ] [code][long-term] 

Expected BIG STUFF that needs handling:
- Darien-specific Classroom & Assignment management will run head-long into the points discussed in #85 , since I'll need to address the hardcoded I2A things in the common Classrooms components.

NOT in the scope:
- Students pages. (i.e. "view my Assignments, view my Classrooms")


### Status
WIP