### PR TITLE
Use scroll to top behavior when program home is mounted

### DIFF
--- a/src/components/common/ProgramHome.jsx
+++ b/src/components/common/ProgramHome.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import Article from 'grommet/components/Article';
+import ScrollToTopOnMount from '../../containers/common/ScrollToTopOnMount';
 
 export default function ProgramHome(props) {
   const programHomeClassnames = classnames(
@@ -10,6 +11,7 @@ export default function ProgramHome(props) {
 
   return (
     <Article className={programHomeClassnames} colorIndex="accent-3">
+      <ScrollToTopOnMount />
       {props.children}
     </Article>
   );

--- a/src/containers/common/ScrollToTopOnMount.jsx
+++ b/src/containers/common/ScrollToTopOnMount.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+class ScrollToTopOnMount extends React.Component {
+  componentDidMount(prevProps) {
+    window.scrollTo(0, 0);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default ScrollToTopOnMount;
+


### PR DESCRIPTION
This adds a scroll to top component to handle this behavior when desired as documented in the RR v4 docs. I added it to the ProgramHome component because it makes sense there. It can be added elsewhere as needed.