### PR TITLE
Show the same message as pending for exports in the processing state

### DIFF
--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -93,7 +93,7 @@ Effect('getCaesarExports', (data) => {
       // We check if there are any complete exports and if there are, we use the most recent complete export
       if (caesarExports.length > 0) {
         const pendingExports = caesarExports.filter((caesarExport) => {
-          return caesarExport.status === 'pending';
+          return caesarExport.status === 'pending' || caesarExport.status === 'processing';
         });
 
         const completedExports = caesarExports.filter((caesarExport) => {


### PR DESCRIPTION
This adds the `processing` state for caesar exports to the pending filter to use the same message as displayed for the pending state. 