### PR TITLE
WildCam Lab Classrooms - 2018 Rebuild - part 2

### DIFF
--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -118,13 +118,13 @@ class ClassroomForm extends React.Component {
     if (!props.selectedProgram) return;
     if (props.mode === MODES.EDIT && !props.selectedClassroom) return;
     
-    if (this.props.mode === MODES.CREATE) {
+    if (props.mode === MODES.CREATE) {
       return Actions.wcc_teachers_createClassroom({
         attributes: this.state.form,
         relationships: {
           program: {
             data: {
-              id: String(this.props.selectedProgram.id),
+              id: String(props.selectedProgram.id),
               type: "programs"
             }
           }
@@ -140,6 +140,23 @@ class ClassroomForm extends React.Component {
           Actions.wildcamClassrooms.resetSelectedClassroom();
           Actions.wildcamClassrooms.setComponentMode(WILDCAMCLASSROOMS_COMPONENT_MODES.VIEW_ALL_CLASSROOMS);
         });
+      }).catch((err) => {
+        //Error messaging done in Actions.wcc_teachers_createClassroom()
+      });
+    } else if (props.mode === MODES.EDIT) {
+      console.log('+++ state.form: ', this.state.form);
+      return Actions.wcc_teachers_editClassroom({
+        selectedClassroom: props.selectedClassroom,
+        classroomData: this.state.form,
+      }).then((what) => {
+        console.log('+++ what ', what);
+        
+        //Message
+        Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.CLASSROOM_EDITED, status: 'ok' });
+        
+        //Refresh
+        //TODO
+        
       }).catch((err) => {
         //Error messaging done in Actions.wcc_teachers_createClassroom()
       });

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -132,11 +132,21 @@ class ClassroomForm extends React.Component {
     //  ? props.assignments[props.selectedClassroom.id]
     //  : [];
     
-    if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
-      return this.render_readyState();
-    } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
-      return this.render_sendingState();
-    }
+    return (
+      <Box
+        className="classroom-form"
+        margin="medium"
+        pad="medium"
+      >
+        {(() => {
+          if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
+            return this.render_readyState();
+          } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
+            return this.render_sendingState();
+          }
+        })()}
+      </Box>
+    );
     
     return null;
   }
@@ -146,73 +156,68 @@ class ClassroomForm extends React.Component {
     const state = this.state;
     
     return (
-      <Box
-        className="classroom-form"
-        margin="medium"
-        pad="medium"
+      
+      <Form
+        onSubmit={this.submitForm.bind(this)}
       >
-        <Form
-          onSubmit={this.submitForm.bind(this)}
-        >
-          <Heading tag="h2">
-            {(()=>{
-              switch (state.mode) {
-                case MODES.CREATE:
-                  return 'Create new classroom';
-                case MODES.EDIT:
-                  return 'Edit classroom';
-                default:
-                  return '???';
-              }
-            })()}
-          </Heading>
+        <Heading tag="h2">
+          {(()=>{
+            switch (state.mode) {
+              case MODES.CREATE:
+                return 'Create new classroom';
+              case MODES.EDIT:
+                return 'Edit classroom';
+              default:
+                return '???';
+            }
+          })()}
+        </Heading>
 
-          <fieldset>
-            <FormField htmlFor="name" label="Classroom Name">
-              <TextInput
-                id="name"
-                required={true}
-                value={this.state.form.name}
-                onDOMChange={this.updateForm.bind(this)}
-              />
-            </FormField>
-          </fieldset>
+        <fieldset>
+          <FormField htmlFor="name" label="Classroom Name">
+            <TextInput
+              id="name"
+              required={true}
+              value={this.state.form.name}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
 
-          <fieldset>
-            <FormField htmlFor="subject" label="Classroom Subject">
-              <TextInput
-                id="subject"
-                value={this.state.form.subject}
-                onDOMChange={this.updateForm.bind(this)}
-              />
-            </FormField>
-          </fieldset>
+        <fieldset>
+          <FormField htmlFor="subject" label="Classroom Subject">
+            <TextInput
+              id="subject"
+              value={this.state.form.subject}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
 
-          <fieldset>
-            <FormField htmlFor="school" label="School Name">
-              <TextInput
-                id="school"
-                value={this.state.form.school}
-                onDOMChange={this.updateForm.bind(this)}
-              />
-            </FormField>
-          </fieldset>
+        <fieldset>
+          <FormField htmlFor="school" label="School Name">
+            <TextInput
+              id="school"
+              value={this.state.form.school}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
 
-          <fieldset>
-            <FormField htmlFor="school" label="Description">
-              <TextInput
-                id="description"
-                value={this.state.form.description}
-                onDOMChange={this.updateForm.bind(this)}
-              />
-            </FormField>
-          </fieldset>
+        <fieldset>
+          <FormField htmlFor="school" label="Description">
+            <TextInput
+              id="description"
+              value={this.state.form.description}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
 
-          <Footer>
-            <Button className="button--primary" type="submit" label="Submit..." primary={true} />
-          </Footer>
-        </Form>
-      </Box>
+        <Footer>
+          <Button className="button--primary" type="submit" label="Submit..." primary={true} />
+        </Footer>
+      </Form>
     );
   }
   

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -21,6 +21,8 @@ import Label from 'grommet/components/Label';
 import TextInput from 'grommet/components/TextInput';
 
 import LinkPreviousIcon from 'grommet/components/icons/base/LinkPrevious';
+import LinkNextIcon from 'grommet/components/icons/base/LinkNext';
+import CloseIcon from 'grommet/components/icons/base/Close';
 import SpinningIcon from 'grommet/components/icons/Spinning';
 
 //import { config } from '../../../lib/config';
@@ -33,6 +35,7 @@ const VIEWS = {
 const TEXT = {
   BACK: 'Back',
   SUBMIT: 'Submit',
+  DELETE: 'Delete',
   WORKING: 'Working...',
   CREATE_NEW_CLASSROOM: 'Create new classroom',
   EDIT_CLASSROOM: 'Edit classroom',
@@ -48,6 +51,7 @@ const TEXT = {
   SUCCESS: {
     CLASSROOM_CREATED: 'Classroom created',
     CLASSROOM_EDITED: 'Changes saved',
+    CLASSROOM_DELETED: 'Classroom deleted',
   },
 };
 
@@ -81,13 +85,9 @@ class ClassroomForm extends React.Component {
   /*  Initialises the classroom form.
    */
   initialiseForm(selectedClassroom) {
-    console.log('+++ initialiseForm: ', this.props.view);
-    
     if (this.props.view === VIEWS.CREATE) {
       this.setState({ form: INITIAL_FORM_DATA });
     } else {
-      console.log('+++ initialiseForm - selectedClassroom: ', selectedClassroom);
-      
       const originalForm = INITIAL_FORM_DATA;
       const updatedForm = {};
       Object.keys(originalForm).map((key) => {
@@ -217,7 +217,7 @@ class ClassroomForm extends React.Component {
         onSubmit={this.submitForm.bind(this)}
       >
         <Heading tag="h2">
-          {(()=>{
+          {(() => {
             switch (props.view) {
               case VIEWS.CREATE:
                 return TEXT.CREATE_NEW_CLASSROOM;
@@ -270,8 +270,12 @@ class ClassroomForm extends React.Component {
           </FormField>
         </fieldset>
 
-        <Footer>
+        <Footer
+          className="actions-panel"
+          pad="medium"
+        >
           <Button
+            className="button"
             icon={<LinkPreviousIcon size="small" />}
             label={TEXT.BACK}
             onClick={() => {
@@ -281,10 +285,38 @@ class ClassroomForm extends React.Component {
             }}
           />
           <Button
+            className="button"
+            icon={<LinkNextIcon size="small" />}
             label={TEXT.SUBMIT}
             primary={true}
             type="submit"
           />
+          {(props.view !== VIEWS.EDIT && props.selectedClassroom) ? null
+            : (
+              <Button
+                className="button"
+                icon={<CloseIcon size="small" />}
+                label={TEXT.DELETE}
+                onClick={() => {
+                  return Actions.wcc_teachers_deleteClassroom(props.selectedClassroom)
+                  .then(() => {
+                    //Message
+                    Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.CLASSROOM_DELETED, status: 'ok' });
+
+                    //Refresh
+                    //Note: this will set the data state to 'sending'.
+                    Actions.wcc_teachers_fetchClassrooms(props.selectedProgram).then(() => {
+                      //Transition to: View All Classrooms
+                      Actions.wildcamClassrooms.resetSelectedClassroom();
+                      Actions.wildcamClassrooms.setComponentMode(WILDCAMCLASSROOMS_COMPONENT_MODES.VIEW_ALL_CLASSROOMS);
+                    });
+                  }).catch((err) => {
+                    //Error messaging done in Actions.wcc_teachers_deleteClassroom()
+                  });
+                }}
+              />
+            )
+          }
         </Footer>
       </Form>
     );

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -19,6 +19,8 @@ import FormField from 'grommet/components/FormField';
 import Heading from 'grommet/components/Heading';
 import TextInput from 'grommet/components/TextInput';
 
+import LinkPreviousIcon from 'grommet/components/icons/base/LinkPrevious';
+
 //import { config } from '../../../lib/config';
 
 const MODES = {
@@ -28,6 +30,7 @@ const MODES = {
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
+  WILDCAMCLASSROOMS_COMPONENT_MODES,
   WILDCAMCLASSROOMS_DATA_STATUS,
   WILDCAMCLASSROOMS_INITIAL_STATE,
   WILDCAMCLASSROOMS_PROPTYPES,
@@ -171,6 +174,16 @@ class ClassroomForm extends React.Component {
             }
           })()}
         </Heading>
+        
+        <Box>
+          <Button
+            icon={<LinkPreviousIcon size="small" />}
+            onClick={() => {
+              Actions.wildcamClassrooms.resetSelectedClassroom();
+              Actions.wildcamClassrooms.setComponentMode(WILDCAMCLASSROOMS_COMPONENT_MODES.VIEW_ALL_CLASSROOMS);
+            }}
+          />
+        </Box>
 
         <fieldset>
           <FormField htmlFor="name" label="Classroom Name">

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -95,8 +95,10 @@ class ClassroomForm extends React.Component {
         attributes: this.state.form,
         relationships: {
           program: {
-            data: String(this.props.selectedProgram.id),
-            type: "programs"
+            data: {
+              id: String(this.props.selectedProgram.id),
+              type: "programs"
+            }
           }
         }
       });

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import { Actions } from 'jumpstate';
 
 import Heading from 'grommet/components/Heading';
+import Box from 'grommet/components/Box';
 import Footer from 'grommet/components/Footer';
 import Form from 'grommet/components/Form';
 import FormField from 'grommet/components/FormField';
@@ -31,7 +32,7 @@ const INITIAL_FORM_DATA = {
   subject: '',
   school: '',
   description: '',
-}
+};
 
 const MODES = {
   INIT: 'init',  //Invalid state.
@@ -50,19 +51,6 @@ class ClassroomForm extends React.Component {
   
   // ----------------------------------------------------------------
   
-  updateForm(e) {
-    this.setState({
-      form: {
-        ...this.state.form,
-        [e.target.id]: e.target.value
-      }
-    });
-    
-    //Apparently [square_brackets] a superconvenient way of specifying an
-    //object key name that's variable. Sweet.
-    
-  }
-
   /*  Initialises the classroom form. Two paths:
       - If there's a classroom selected, we want to EDIT/VIEW it.
       - If there's NO classroom selected, we want to CREATE one.
@@ -82,6 +70,27 @@ class ClassroomForm extends React.Component {
     }
   }
   
+  updateForm(e) {
+    this.setState({
+      form: {
+        ...this.state.form,
+        [e.target.id]: e.target.value
+      }
+    });
+    
+    //Apparently [square_brackets] a superconvenient way of specifying an
+    //object key name that's variable. Sweet.
+    
+  }
+  
+  submitForm(e) {
+    e.preventDefault();
+    
+    if (this.state.mode === MODES.CREATE) {
+      Actions.wcc_teachers_createClassroom(this.state.form);
+    }
+  }
+  
   // ----------------------------------------------------------------
 
   componentDidMount() {
@@ -98,21 +107,34 @@ class ClassroomForm extends React.Component {
 
   render() {
     const props = this.props;
-    const state = this.state;
-    const joinURL = props.selectedClassroom
-      ? `${config.origin}/#/${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}`
-      : '';
+    //const state = this.state;
+    //const joinURL = props.selectedClassroom
+    //  ? `${config.origin}/#/${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}`
+    //  : '';
 
     //Get students and assignments only for this classroom.
-    const students = (props.selectedClassroom && props.selectedClassroom.students) ? props.selectedClassroom.students : [];
-    const assignments = (props.selectedClassroom && props.assignments && props.assignments[props.selectedClassroom.id])
-      ? props.assignments[props.selectedClassroom.id]
-      : [];
-
+    //const students = (props.selectedClassroom && props.selectedClassroom.students) ? props.selectedClassroom.students : [];
+    //const assignments = (props.selectedClassroom && props.assignments && props.assignments[props.selectedClassroom.id])
+    //  ? props.assignments[props.selectedClassroom.id]
+    //  : [];
+    
+    if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
+      return this.render_readyState();
+    } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
+      return this.render_sendingState();
+    }
+    
+    return null;
+  }
+  
+  render_readyState() {
+    const props = this.props;
+    const state = this.state;
+    
     return (
       <Form
         className="classroom-form"
-        onSubmit={()=>{}}
+        onSubmit={this.submitForm.bind(this)}
         pad="medium"
       >
         <Heading tag="h2">
@@ -170,9 +192,19 @@ class ClassroomForm extends React.Component {
         </fieldset>
 
         <Footer>
-          <Button className="button--primary" type="submit" label="Sumbit..." primary={true} />
+          <Button className="button--primary" type="submit" label="Submit..." primary={true} />
         </Footer>
       </Form>
+    );
+  }
+  
+  render_sendingState() {
+    const props = this.props;
+    
+    return (
+      <Box>
+        Sending...
+      </Box>
     );
   }
 };

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -25,7 +25,7 @@ import SpinningIcon from 'grommet/components/icons/Spinning';
 
 //import { config } from '../../../lib/config';
 
-const MODES = {
+const VIEWS = {
   CREATE: 'create',
   EDIT: 'edit',
 }
@@ -81,9 +81,13 @@ class ClassroomForm extends React.Component {
   /*  Initialises the classroom form.
    */
   initialiseForm(selectedClassroom) {
-    if (this.props.mode === MODES.CREATE) {
+    console.log('+++ initialiseForm: ', this.props.view);
+    
+    if (this.props.view === VIEWS.CREATE) {
       this.setState({ form: INITIAL_FORM_DATA });
     } else {
+      console.log('+++ initialiseForm - selectedClassroom: ', selectedClassroom);
+      
       const originalForm = INITIAL_FORM_DATA;
       const updatedForm = {};
       Object.keys(originalForm).map((key) => {
@@ -116,9 +120,9 @@ class ClassroomForm extends React.Component {
     
     //Sanity check
     if (!props.selectedProgram) return;
-    if (props.mode === MODES.EDIT && !props.selectedClassroom) return;
+    if (props.view === VIEWS.EDIT && !props.selectedClassroom) return;
     
-    if (props.mode === MODES.CREATE) {
+    if (props.view === VIEWS.CREATE) {
       return Actions.wcc_teachers_createClassroom({
         selectedProgram: props.selectedProgram,
         classroomData: this.state.form,
@@ -137,7 +141,7 @@ class ClassroomForm extends React.Component {
       }).catch((err) => {
         //Error messaging done in Actions.wcc_teachers_createClassroom()
       });
-    } else if (props.mode === MODES.EDIT) {
+    } else if (props.view === VIEWS.EDIT) {
       return Actions.wcc_teachers_editClassroom({
         selectedClassroom: props.selectedClassroom,
         classroomData: this.state.form,
@@ -214,10 +218,10 @@ class ClassroomForm extends React.Component {
       >
         <Heading tag="h2">
           {(()=>{
-            switch (props.mode) {
-              case MODES.CREATE:
+            switch (props.view) {
+              case VIEWS.CREATE:
                 return TEXT.CREATE_NEW_CLASSROOM;
-              case MODES.EDIT:
+              case VIEWS.EDIT:
                 return TEXT.EDIT_CLASSROOM
               default:
                 return '???';
@@ -302,9 +306,9 @@ class ClassroomForm extends React.Component {
   }
 };
 
-ClassroomForm.MODES = MODES;
+ClassroomForm.VIEWS = VIEWS;
 ClassroomForm.defaultProps = {
-  mode: MODES.CREATE,
+  view: VIEWS.CREATE,
   // ----------------
   selectedProgram: PROGRAMS_INITIAL_STATE.selectedProgram,
   // ----------------
@@ -314,7 +318,7 @@ ClassroomForm.defaultProps = {
 };
 
 ClassroomForm.propTypes = {
-  mode: PropTypes.string,
+  view: PropTypes.string,
   // ----------------
   selectedProgram: PROGRAMS_PROPTYPES.selectedProgram,
   // ----------------

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -21,6 +21,7 @@ import Button from 'grommet/components/Button';
 
 import { config } from '../../../lib/config';
 
+import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
   WILDCAMCLASSROOMS_DATA_STATUS,
   WILDCAMCLASSROOMS_INITIAL_STATE,
@@ -86,8 +87,19 @@ class ClassroomForm extends React.Component {
   submitForm(e) {
     e.preventDefault();
     
+    //Sanity check
+    if (!this.props.selectedProgram) return;
+    
     if (this.state.mode === MODES.CREATE) {
-      Actions.wcc_teachers_createClassroom(this.state.form);
+      return Actions.wcc_teachers_createClassroom({
+        attributes: this.state.form,
+        relationships: {
+          program: {
+            data: String(this.props.selectedProgram.id),
+            type: "programs"
+          }
+        }
+      });
     }
   }
   
@@ -210,11 +222,17 @@ class ClassroomForm extends React.Component {
 };
 
 ClassroomForm.defaultProps = {
-  ...WILDCAMCLASSROOMS_INITIAL_STATE.selectedClassroom,
+  selectedProgram: PROGRAMS_INITIAL_STATE.selectedProgram,
+  // ----------------
+  classroomsStatus: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsStatus,
+  selectedClassroom: WILDCAMCLASSROOMS_INITIAL_STATE.selectedClassroom,
 };
 
 ClassroomForm.propTypes = {
-  ...WILDCAMCLASSROOMS_PROPTYPES.selectedClassroom,
+  selectedProgram: PROGRAMS_PROPTYPES.selectedProgram,
+  // ----------------
+  classroomsStatus: WILDCAMCLASSROOMS_PROPTYPES.classroomsStatus,
+  selectedClassroom: WILDCAMCLASSROOMS_PROPTYPES.selectedClassroom,
 };
 
 export default ClassroomForm;

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -17,9 +17,11 @@ import Footer from 'grommet/components/Footer';
 import Form from 'grommet/components/Form';
 import FormField from 'grommet/components/FormField';
 import Heading from 'grommet/components/Heading';
+import Label from 'grommet/components/Label';
 import TextInput from 'grommet/components/TextInput';
 
 import LinkPreviousIcon from 'grommet/components/icons/base/LinkPrevious';
+import SpinningIcon from 'grommet/components/icons/Spinning';
 
 //import { config } from '../../../lib/config';
 
@@ -27,6 +29,20 @@ const MODES = {
   CREATE: 'create',
   EDIT: 'edit',
 }
+
+const TEXT = {
+  BACK: 'Back',
+  SUBMIT: 'Submit',
+  WORKING: 'Working...',
+  CREATE_NEW_CLASSROOM: 'Create new classroom',
+  EDIT_CLASSROOM: 'Edit classroom',
+  CLASSROOM_FORM: {
+    NAME: 'Classroom name',
+    SUBJECT: 'Classroom subject',
+    SCHOOL: 'School',
+    DESCRIPTION: 'Description',
+  }
+};
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
@@ -68,7 +84,6 @@ class ClassroomForm extends React.Component {
           ? selectedClassroom[key]
           : originalForm[key];
       });
-      console.log('+++ ', updatedForm);
       this.setState({ form: updatedForm });
     }
   }
@@ -144,7 +159,7 @@ class ClassroomForm extends React.Component {
           if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
             return this.render_readyState();
           } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
-            return this.render_sendingState();
+            return this.render_workingState();
           }
         })()}
       </Box>
@@ -158,35 +173,25 @@ class ClassroomForm extends React.Component {
     const state = this.state;
     
     return (
-      
       <Form
+        className="form"
         onSubmit={this.submitForm.bind(this)}
       >
         <Heading tag="h2">
           {(()=>{
             switch (props.mode) {
               case MODES.CREATE:
-                return 'Create new classroom';
+                return TEXT.CREATE_NEW_CLASSROOM;
               case MODES.EDIT:
-                return 'Edit classroom';
+                return TEXT.EDIT_CLASSROOM
               default:
                 return '???';
             }
           })()}
         </Heading>
-        
-        <Box>
-          <Button
-            icon={<LinkPreviousIcon size="small" />}
-            onClick={() => {
-              Actions.wildcamClassrooms.resetSelectedClassroom();
-              Actions.wildcamClassrooms.setComponentMode(WILDCAMCLASSROOMS_COMPONENT_MODES.VIEW_ALL_CLASSROOMS);
-            }}
-          />
-        </Box>
 
         <fieldset>
-          <FormField htmlFor="name" label="Classroom Name">
+          <FormField htmlFor="name" label={TEXT.CLASSROOM_FORM.NAME}>
             <TextInput
               id="name"
               required={true}
@@ -197,7 +202,7 @@ class ClassroomForm extends React.Component {
         </fieldset>
 
         <fieldset>
-          <FormField htmlFor="subject" label="Classroom Subject">
+          <FormField htmlFor="subject" label={TEXT.CLASSROOM_FORM.SUBJECT}>
             <TextInput
               id="subject"
               value={this.state.form.subject}
@@ -207,7 +212,7 @@ class ClassroomForm extends React.Component {
         </fieldset>
 
         <fieldset>
-          <FormField htmlFor="school" label="School Name">
+          <FormField htmlFor="school" label={TEXT.CLASSROOM_FORM.SCHOOL}>
             <TextInput
               id="school"
               value={this.state.form.school}
@@ -217,7 +222,7 @@ class ClassroomForm extends React.Component {
         </fieldset>
 
         <fieldset>
-          <FormField htmlFor="school" label="Description">
+          <FormField htmlFor="school" label={TEXT.CLASSROOM_FORM.DESCRIPTION}>
             <TextInput
               id="description"
               value={this.state.form.description}
@@ -227,16 +232,35 @@ class ClassroomForm extends React.Component {
         </fieldset>
 
         <Footer>
-          <Button className="button--primary" type="submit" label="Submit..." primary={true} />
+          <Button
+            icon={<LinkPreviousIcon size="small" />}
+            label={TEXT.BACK}
+            onClick={() => {
+              Actions.wildcamClassrooms.resetSelectedClassroom();
+              Actions.wildcamClassrooms.setComponentMode(WILDCAMCLASSROOMS_COMPONENT_MODES.VIEW_ALL_CLASSROOMS);
+            }}
+          />
+          <Button
+            label={TEXT.SUBMIT}
+            primary={true}
+            type="submit"
+          />
         </Footer>
       </Form>
     );
   }
   
-  render_sendingState() {
+  render_workingState() {
     return (
-      <Box>
-        Sending...
+      <Box
+        align="center"
+        alignContent="center"
+        className="status-box"
+        direction="column"
+        pad="medium"
+      >
+        <SpinningIcon />
+        <Label>{TEXT.WORKING}</Label>
       </Box>
     );
   }

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -146,69 +146,73 @@ class ClassroomForm extends React.Component {
     const state = this.state;
     
     return (
-      <Form
+      <Box
         className="classroom-form"
-        onSubmit={this.submitForm.bind(this)}
+        margin="medium"
         pad="medium"
       >
-        <Heading tag="h2">
-          {(()=>{
-            switch (state.mode) {
-              case MODES.CREATE:
-                return 'Create new classroom';
-              case MODES.EDIT:
-                return 'Edit classroom';
-              default:
-                return '???';
-            }
-          })()}
-        </Heading>
+        <Form
+          onSubmit={this.submitForm.bind(this)}
+        >
+          <Heading tag="h2">
+            {(()=>{
+              switch (state.mode) {
+                case MODES.CREATE:
+                  return 'Create new classroom';
+                case MODES.EDIT:
+                  return 'Edit classroom';
+                default:
+                  return '???';
+              }
+            })()}
+          </Heading>
 
-        <fieldset>
-          <FormField htmlFor="name" label="Classroom Name">
-            <TextInput
-              id="name"
-              required={true}
-              value={this.state.form.name}
-              onDOMChange={this.updateForm.bind(this)}
-            />
-          </FormField>
-        </fieldset>
-        
-        <fieldset>
-          <FormField htmlFor="subject" label="Classroom Subject">
-            <TextInput
-              id="subject"
-              value={this.state.form.subject}
-              onDOMChange={this.updateForm.bind(this)}
-            />
-          </FormField>
-        </fieldset>
-        
-        <fieldset>
-          <FormField htmlFor="school" label="School Name">
-            <TextInput
-              id="school"
-              value={this.state.form.school}
-              onDOMChange={this.updateForm.bind(this)}
-            />
-          </FormField>
-        </fieldset>
-        
-        <fieldset>
-          <FormField htmlFor="school" label="Description">
-            <TextInput
-              id="description"
-              value={this.state.form.description}
-              onDOMChange={this.updateForm.bind(this)}
-            />
-          </FormField>
-        </fieldset>
+          <fieldset>
+            <FormField htmlFor="name" label="Classroom Name">
+              <TextInput
+                id="name"
+                required={true}
+                value={this.state.form.name}
+                onDOMChange={this.updateForm.bind(this)}
+              />
+            </FormField>
+          </fieldset>
 
-        <Footer>
-          <Button className="button--primary" type="submit" label="Submit..." primary={true} />
-        </Footer>
-      </Form>
+          <fieldset>
+            <FormField htmlFor="subject" label="Classroom Subject">
+              <TextInput
+                id="subject"
+                value={this.state.form.subject}
+                onDOMChange={this.updateForm.bind(this)}
+              />
+            </FormField>
+          </fieldset>
+
+          <fieldset>
+            <FormField htmlFor="school" label="School Name">
+              <TextInput
+                id="school"
+                value={this.state.form.school}
+                onDOMChange={this.updateForm.bind(this)}
+              />
+            </FormField>
+          </fieldset>
+
+          <fieldset>
+            <FormField htmlFor="school" label="Description">
+              <TextInput
+                id="description"
+                value={this.state.form.description}
+                onDOMChange={this.updateForm.bind(this)}
+              />
+            </FormField>
+          </fieldset>
+
+          <Footer>
+            <Button className="button--primary" type="submit" label="Submit..." primary={true} />
+          </Footer>
+        </Form>
+      </Box>
     );
   }
   

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -1,0 +1,88 @@
+/*
+ClassroomForm
+-------------
+
+Component for viewing or editing a single classroom.
+
+--------------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Actions } from 'jumpstate';
+
+import Heading from 'grommet/components/Heading';
+import Footer from 'grommet/components/Footer';
+import Form from 'grommet/components/Form';
+import FormField from 'grommet/components/FormField';
+import TextInput from 'grommet/components/TextInput';
+import Button from 'grommet/components/Button';
+
+import { config } from '../../../lib/config';
+
+import {
+  WILDCAMCLASSROOMS_DATA_STATUS,
+  WILDCAMCLASSROOMS_INITIAL_STATE,
+  WILDCAMCLASSROOMS_PROPTYPES,
+} from '../ducks/index.js';
+
+class ClassroomForm extends React.Component {
+  constructor() {
+    super();
+  
+    this.state = {
+      name: '',
+    };
+  }
+  
+  updateForm() {
+    
+  }
+
+  render() {
+    const props = this.props;
+    const joinURL = props.selectedClassroom
+      ? `${config.origin}/#/${props.selectedProgram.slug}/students/classrooms/${props.selectedClassroom.id}/join?token=${props.selectedClassroom.joinToken}`
+      : '';
+
+    // Get students and assignments only for this classroom.
+    const students = (props.selectedClassroom && props.selectedClassroom.students) ? props.selectedClassroom.students : [];
+    const assignments = (props.selectedClassroom && props.assignments && props.assignments[props.selectedClassroom.id])
+      ? props.assignments[props.selectedClassroom.id]
+      : [];
+
+    return (
+      <Form
+        className="classroom-form"
+        onSubmit={()=>{}}
+        pad="medium"
+      >
+        <Heading tag="h2">TEST...</Heading>
+
+        <fieldset>
+          <FormField htmlFor="name" label="Name">
+            <TextInput
+              id="name"
+              required={true}
+              value={'Example Classroom 1'}
+            />
+          </FormField>
+        </fieldset>
+
+        <Footer>
+          <Button className="button--primary" type="submit" label="Sumbit..." primary={true} />
+        </Footer>
+      </Form>
+    );
+  }
+};
+
+ClassroomForm.defaultProps = {
+  ...WILDCAMCLASSROOMS_INITIAL_STATE,
+};
+
+ClassroomForm.propTypes = {
+  ...WILDCAMCLASSROOMS_PROPTYPES,
+};
+
+export default ClassroomForm;

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -19,7 +19,7 @@ import FormField from 'grommet/components/FormField';
 import TextInput from 'grommet/components/TextInput';
 import Button from 'grommet/components/Button';
 
-import { config } from '../../../lib/config';
+//import { config } from '../../../lib/config';
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -87,7 +87,7 @@ class ClassroomForm extends React.Component {
       const originalForm = INITIAL_FORM_DATA;
       const updatedForm = {};
       Object.keys(originalForm).map((key) => {
-        updatedForm[key] = (selectedClassroom[key])
+        updatedForm[key] = (selectedClassroom && selectedClassroom[key])
           ? selectedClassroom[key]
           : originalForm[key];
       });
@@ -146,7 +146,11 @@ class ClassroomForm extends React.Component {
         Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.CLASSROOM_EDITED, status: 'ok' });
         
         //Refresh
-        //TODO        
+        return Actions.wcc_teachers_refreshView({
+          program: props.selectedProgram,
+          componentMode: props.componentMode,
+          selectedClassroom: props.selectedClassroom,
+        });
       }).catch((err) => {
         //Error messaging done in Actions.wcc_teachers_createClassroom()
       });
@@ -304,6 +308,7 @@ ClassroomForm.defaultProps = {
   // ----------------
   selectedProgram: PROGRAMS_INITIAL_STATE.selectedProgram,
   // ----------------
+  componentMode: WILDCAMCLASSROOMS_INITIAL_STATE.componentMode,
   classroomsStatus: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsStatus,
   selectedClassroom: WILDCAMCLASSROOMS_INITIAL_STATE.selectedClassroom,
 };
@@ -313,6 +318,7 @@ ClassroomForm.propTypes = {
   // ----------------
   selectedProgram: PROGRAMS_PROPTYPES.selectedProgram,
   // ----------------
+  componentMode: WILDCAMCLASSROOMS_PROPTYPES.componentMode,
   classroomsStatus: WILDCAMCLASSROOMS_PROPTYPES.classroomsStatus,
   selectedClassroom: WILDCAMCLASSROOMS_PROPTYPES.selectedClassroom,
 };

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -120,16 +120,10 @@ class ClassroomForm extends React.Component {
     
     if (props.mode === MODES.CREATE) {
       return Actions.wcc_teachers_createClassroom({
-        attributes: this.state.form,
-        relationships: {
-          program: {
-            data: {
-              id: String(props.selectedProgram.id),
-              type: "programs"
-            }
-          }
-        }
-      }).then(() => {
+        selectedProgram: props.selectedProgram,
+        classroomData: this.state.form,
+      })
+      .then(() => {
         //Message
         Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.CLASSROOM_CREATED, status: 'ok' });
         
@@ -144,19 +138,15 @@ class ClassroomForm extends React.Component {
         //Error messaging done in Actions.wcc_teachers_createClassroom()
       });
     } else if (props.mode === MODES.EDIT) {
-      console.log('+++ state.form: ', this.state.form);
       return Actions.wcc_teachers_editClassroom({
         selectedClassroom: props.selectedClassroom,
         classroomData: this.state.form,
       }).then((what) => {
-        console.log('+++ what ', what);
-        
         //Message
         Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.CLASSROOM_EDITED, status: 'ok' });
         
         //Refresh
-        //TODO
-        
+        //TODO        
       }).catch((err) => {
         //Error messaging done in Actions.wcc_teachers_createClassroom()
       });

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -32,12 +32,35 @@ class ClassroomForm extends React.Component {
   
     this.state = {
       name: '',
+      subject: '',
+      school: '',
+      description: '',
     };
+
+    this.loadSelectedClassroomDetails(this.props);
   }
   
-  updateForm() {
+  /*  Update the form details.
+   */
+  updateForm(e) {
+    console.log('+++ ', { [e.target.id]: e.target.value });
+    this.setState({
+      [e.target.id]: e.target.value
+      //Apparently [square_brackets] a superconvenient way of specifying an
+      //object key name that's variable. Sweet.
+    });
     
   }
+  
+  loadSelectedClassroomDetails(props) {
+  }
+
+  componentWillReceiveProps(nextProps) {
+    
+    
+    this.loadSelectedClassroomDetails(nextProps);
+  }
+  
 
   render() {
     const props = this.props;
@@ -60,11 +83,42 @@ class ClassroomForm extends React.Component {
         <Heading tag="h2">TEST...</Heading>
 
         <fieldset>
-          <FormField htmlFor="name" label="Name">
+          <FormField htmlFor="name" label="Classroom Name">
             <TextInput
               id="name"
               required={true}
-              value={'Example Classroom 1'}
+              value={this.state.name}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
+        
+        <fieldset>
+          <FormField htmlFor="subject" label="Classroom Subject">
+            <TextInput
+              id="subject"
+              value={this.state.subject}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
+        
+        <fieldset>
+          <FormField htmlFor="school" label="School Name">
+            <TextInput
+              id="school"
+              value={this.state.school}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
+        
+        <fieldset>
+          <FormField htmlFor="school" label="Description">
+            <TextInput
+              id="description"
+              value={this.state.description}
+              onDOMChange={this.updateForm.bind(this)}
             />
           </FormField>
         </fieldset>

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -72,8 +72,12 @@ class ClassroomsList extends React.Component {
     
     return (
       <Box>
-        <Box pad="medium">
+        <Box
+          className="actions-panel"
+          pad="medium"
+        >
           <Button
+            className="button"
             icon={<AddIcon size="small" />}
             label={TEXT.CREATE_NEW_CLASSROOM}
             onClick={() => {
@@ -93,8 +97,9 @@ class ClassroomsList extends React.Component {
                 key={`classrooms-list_${index}`}
               >
                 <td>{classroom.name}</td>
-                <td>
+                <td className="actions-panel">
                   <Button
+                    className="button"
                     icon={<EditIcon size="small" />}
                     label="Edit"
                     onClick={() => {

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -13,12 +13,14 @@ import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
+import Label from 'grommet/components/Label';
 import Heading from 'grommet/components/Heading';
 import Table from 'grommet/components/Table';
 import TableRow from 'grommet/components/TableRow';
 
 import AddIcon from 'grommet/components/icons/base/Add';
 import EditIcon from 'grommet/components/icons/base/Edit';
+import SpinningIcon from 'grommet/components/icons/Spinning';
 
 import {
   WILDCAMCLASSROOMS_COMPONENT_MODES as MODES,
@@ -26,6 +28,12 @@ import {
   WILDCAMCLASSROOMS_INITIAL_STATE,
   WILDCAMCLASSROOMS_PROPTYPES,
 } from '../ducks/index.js';
+  
+const TEXT = {
+  WORKING: 'Working...',
+  EDIT: 'Edit',
+  CREATE_NEW_CLASSROOM: 'Create new classroom',
+};
 
 class ClassroomsList extends React.Component {
   constructor() {
@@ -48,16 +56,31 @@ class ClassroomsList extends React.Component {
       >
         <Heading tag="h2">List of Classrooms</Heading>
         
+        {(() => {
+          if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
+            return this.render_readyState();
+          } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.FETCHING || props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
+            return this.render_workingState();
+          }
+        })()}
+      </Box>
+    );
+  }
+  
+  render_readyState() {
+    const props = this.props;
+    
+    return (
+      <Box>
         <Box pad="medium">
           <Button
             icon={<AddIcon size="small" />}
+            label={TEXT.CREATE_NEW_CLASSROOM}
             onClick={() => {
               Actions.wildcamClassrooms.resetSelectedClassroom();
               Actions.wildcamClassrooms.setComponentMode(MODES.CREATE_NEW_CLASSROOM);
             }}
-          >
-            Create new classroom
-          </Button>
+          />
         </Box>
         
         <Table className="table">
@@ -72,14 +95,12 @@ class ClassroomsList extends React.Component {
                 <td>
                   <Button
                     icon={<EditIcon size="small" />}
+                    label="Edit"
                     onClick={() => {
-                      console.log('+++ ');
                       Actions.wildcamClassrooms.setSelectedClassroom(classroom);
                       Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ONE_CLASSROOM);
                     }}
-                  >
-                    Edit
-                  </Button>
+                  />
                 </td>
               </TableRow>
             );
@@ -89,14 +110,33 @@ class ClassroomsList extends React.Component {
       </Box>
     );
   }
+  
+  render_workingState() {
+    return (
+      <Box
+        align="center"
+        alignContent="center"
+        className="status-box"
+        direction="column"
+        pad="medium"
+      >
+        <SpinningIcon />
+        <Label>{TEXT.WORKING}</Label>
+      </Box>
+    );
+  }
+
+  
 };
 
 ClassroomsList.defaultProps = {
   classroomsList: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsList,
+  classroomsStatus: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsStatus,
 };
 
 ClassroomsList.propTypes = {
   classroomsList: WILDCAMCLASSROOMS_PROPTYPES.classroomsList,
+  classroomsStatus: WILDCAMCLASSROOMS_PROPTYPES.classroomsStatus,
 };
 
 export default ClassroomsList;

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -16,7 +16,9 @@ import Button from 'grommet/components/Button';
 import Heading from 'grommet/components/Heading';
 import Table from 'grommet/components/Table';
 import TableRow from 'grommet/components/TableRow';
-import Edit from 'grommet/components/icons/base/Edit';
+
+import AddIcon from 'grommet/components/icons/base/Add';
+import EditIcon from 'grommet/components/icons/base/Edit';
 
 import {
   WILDCAMCLASSROOMS_COMPONENT_MODES as MODES,
@@ -47,10 +49,13 @@ class ClassroomsList extends React.Component {
         <Heading tag="h2">List of Classrooms</Heading>
         
         <Box pad="medium">
-          <Button onClick={() => {
-            Actions.wildcamClassrooms.resetSelectedClassroom();
-            Actions.wildcamClassrooms.setComponentMode(MODES.CREATE_NEW_CLASSROOM);
-          }}>
+          <Button
+            icon={<AddIcon size="small" />}
+            onClick={() => {
+              Actions.wildcamClassrooms.resetSelectedClassroom();
+              Actions.wildcamClassrooms.setComponentMode(MODES.CREATE_NEW_CLASSROOM);
+            }}
+          >
             Create new classroom
           </Button>
         </Box>
@@ -66,13 +71,14 @@ class ClassroomsList extends React.Component {
                 <td>{classroom.name}</td>
                 <td>
                   <Button
+                    icon={<EditIcon size="small" />}
                     onClick={() => {
                       console.log('+++ ');
                       Actions.wildcamClassrooms.setSelectedClassroom(classroom);
                       Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ONE_CLASSROOM);
                     }}
                   >
-                    <Edit /> Edit
+                    Edit
                   </Button>
                 </td>
               </TableRow>

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -127,8 +127,6 @@ class ClassroomsList extends React.Component {
       </Box>
     );
   }
-
-  
 };
 
 ClassroomsList.defaultProps = {

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -37,6 +37,7 @@ class ClassroomsList extends React.Component {
     return (
       <Box
         className="classrooms-list"
+        margin="medium"
         pad="medium"
       >
         <Heading tag="h2">List of Classrooms</Heading>

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -1,0 +1,67 @@
+/*
+ClassroomsList
+--------------
+
+Component for listing all classrooms.
+
+--------------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Actions } from 'jumpstate';
+
+import Box from 'grommet/components/Box';
+import Button from 'grommet/components/Button';
+import Heading from 'grommet/components/Heading';
+
+import {
+  WILDCAMCLASSROOMS_DATA_STATUS,
+  WILDCAMCLASSROOMS_INITIAL_STATE,
+  WILDCAMCLASSROOMS_PROPTYPES,
+} from '../ducks/index.js';
+
+class ClassroomsList extends React.Component {
+  constructor() {
+    super();
+  }
+  
+  // ----------------------------------------------------------------
+  
+  render() {
+    const props = this.props;
+    
+    //Sanity check
+    if (!props.classroomsList) return null;
+    
+    return (
+      <Box
+        className="classrooms-list"
+        pad="medium"
+      >
+        <Heading tag="h2">List of Classrooms</Heading>
+        
+        {props.classroomsList.map((classroom, index) => {
+          return (
+            <div
+              className="item"
+              key={`classrooms-list_${index}`}
+            >
+              {classroom.name}
+            </div>
+          );
+        })}
+      </Box>
+    );
+  }
+};
+
+ClassroomsList.defaultProps = {
+  classroomsList: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsList,
+};
+
+ClassroomsList.propTypes = {
+  classroomsList: WILDCAMCLASSROOMS_PROPTYPES.classroomsList,
+};
+
+export default ClassroomsList;

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -14,6 +14,9 @@ import { Actions } from 'jumpstate';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import Heading from 'grommet/components/Heading';
+import Table from 'grommet/components/Table';
+import TableRow from 'grommet/components/TableRow';
+import Edit from 'grommet/components/icons/base/Edit';
 
 import {
   WILDCAMCLASSROOMS_DATA_STATUS,
@@ -42,16 +45,27 @@ class ClassroomsList extends React.Component {
       >
         <Heading tag="h2">List of Classrooms</Heading>
         
-        {props.classroomsList.map((classroom, index) => {
-          return (
-            <div
-              className="item"
-              key={`classrooms-list_${index}`}
-            >
-              {classroom.name}
-            </div>
-          );
-        })}
+        <Table className="table">
+          <tbody>
+          {props.classroomsList.map((classroom, index) => {
+            return (
+              <TableRow
+                className="item"
+                key={`classrooms-list_${index}`}
+              >
+                <td>{classroom.name}</td>
+                <td>
+                  <Button
+                    onClick={() => { Actions.wildcamClassrooms.setSelectedClassroom(classroom) }}
+                  >
+                    <Edit />
+                  </Button>
+                </td>
+              </TableRow>
+            );
+          })}
+          </tbody>
+        </Table>
       </Box>
     );
   }

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -77,6 +77,7 @@ class ClassroomsList extends React.Component {
             icon={<AddIcon size="small" />}
             label={TEXT.CREATE_NEW_CLASSROOM}
             onClick={() => {
+              //Transition to: Create New Classroom
               Actions.wildcamClassrooms.resetSelectedClassroom();
               Actions.wildcamClassrooms.setComponentMode(MODES.CREATE_NEW_CLASSROOM);
             }}
@@ -97,6 +98,7 @@ class ClassroomsList extends React.Component {
                     icon={<EditIcon size="small" />}
                     label="Edit"
                     onClick={() => {
+                      //Transition to: View One Classroom
                       Actions.wildcamClassrooms.setSelectedClassroom(classroom);
                       Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ONE_CLASSROOM);
                     }}

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -19,6 +19,7 @@ import TableRow from 'grommet/components/TableRow';
 import Edit from 'grommet/components/icons/base/Edit';
 
 import {
+  WILDCAMCLASSROOMS_COMPONENT_MODES as MODES,
   WILDCAMCLASSROOMS_DATA_STATUS,
   WILDCAMCLASSROOMS_INITIAL_STATE,
   WILDCAMCLASSROOMS_PROPTYPES,
@@ -45,6 +46,15 @@ class ClassroomsList extends React.Component {
       >
         <Heading tag="h2">List of Classrooms</Heading>
         
+        <Box pad="medium">
+          <Button onClick={() => {
+            Actions.wildcamClassrooms.resetSelectedClassroom();
+            Actions.wildcamClassrooms.setComponentMode(MODES.CREATE_NEW_CLASSROOM);
+          }}>
+            Create new classroom
+          </Button>
+        </Box>
+        
         <Table className="table">
           <tbody>
           {props.classroomsList.map((classroom, index) => {
@@ -56,9 +66,13 @@ class ClassroomsList extends React.Component {
                 <td>{classroom.name}</td>
                 <td>
                   <Button
-                    onClick={() => { Actions.wildcamClassrooms.setSelectedClassroom(classroom) }}
+                    onClick={() => {
+                      console.log('+++ ');
+                      Actions.wildcamClassrooms.setSelectedClassroom(classroom);
+                      Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ONE_CLASSROOM);
+                    }}
                   >
-                    <Edit />
+                    <Edit /> Edit
                   </Button>
                 </td>
               </TableRow>

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -55,10 +55,11 @@ class WildCamClassroom extends React.Component {
   }
   
   initialiseList(props = this.props) {
-    console.log('=== initialiseList');
-    
     //Sanity check
     if (!props.selectedProgram) return;
+    
+    //Initial mode
+    Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ALL_CLASSROOMS);
     
     Actions.wcc_teachers_fetchClassrooms(props.selectedProgram)
     .then(() => {

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -117,14 +117,6 @@ class WildCamClassroom extends React.Component {
             Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
             Component Mode: {props.componentMode}
           </Box>
-          <Box>
-            <Button
-              label="Test Toast"
-              onClick={() => {
-                Actions.wildcamClassrooms.setToast({ status: 'ok', message: 'Debug looks good'});
-              }}
-            />
-          </Box>
         </Box>
 
       </Box>

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -51,6 +51,8 @@ class WildCamClassroom extends React.Component {
   }
   
   initialiseList(props = this.props) {
+    console.log('=== initialiseList');
+    
     //Sanity check
     if (!props.selectedProgram) return;
     
@@ -77,10 +79,6 @@ class WildCamClassroom extends React.Component {
           Classrooms Status: [{props.classroomsStatus}] <br/>
           Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
           Mode: {props.componentMode}
-        </Box>
-        
-        <Box pad="medium">
-          <Button>Create new classroom</Button>
         </Box>
         
         {props.componentMode === MODES.INIT && (

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -21,19 +21,12 @@ import ClassroomForm from '../components/ClassroomForm';
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
-  WILDCAMCLASSROOMS_COMPONENT_MODE as MODE,
+  WILDCAMCLASSROOMS_COMPONENT_MODES as MODES,
   WILDCAMCLASSROOMS_DATA_STATUS,
   WILDCAMCLASSROOMS_INITIAL_STATE,
   WILDCAMCLASSROOMS_PROPTYPES,
   WILDCAMCLASSROOMS_MAP_STATE,
 } from '../ducks/index.js';
-
-const MODES = {
-  INIT: 'init',
-  VIEW_ALL_CLASSROOMS: 'view all classrooms',
-  VIEW_ONE_CLASSROOM: 'view one classroom',
-  CREATE_NEW_CLASSROOM: 'create new classroom',
-};
 
 const TEXT = {
   

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -14,7 +14,6 @@ import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
-import Spinning from 'grommet/components/icons/Spinning';
 
 import ClassroomsList from '../components/ClassroomsList';
 import ClassroomForm from '../components/ClassroomForm';
@@ -33,6 +32,10 @@ const MODES = {
   VIEW_ALL_CLASSROOMS: 'view all classrooms',
   VIEW_ONE_CLASSROOM: 'view one classroom',
   CREATE_NEW_CLASSROOM: 'create new classroom',
+};
+
+const TEXT = {
+  
 };
 
 class WildCamClassroom extends React.Component {
@@ -79,19 +82,14 @@ class WildCamClassroom extends React.Component {
           Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
           Mode: {props.componentMode}
         </Box>
-        
-        {props.componentMode === MODES.INIT && (
-          <Box pad="medium">
-            <Spinning />
-          </Box>
-        )}
-        
+
         {props.componentMode === MODES.VIEW_ALL_CLASSROOMS && (
           <ClassroomsList
             classroomsList={props.classroomsList}
+            classroomsStatus={props.classroomsStatus}
           />
         )}
-        
+
         {props.componentMode === MODES.VIEW_ONE_CLASSROOM && (
           <ClassroomForm
             mode={ClassroomForm.MODES.EDIT}

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -93,16 +93,18 @@ class WildCamClassroom extends React.Component {
           />
         )}
         
-        {props.componentMode === MODES.VIEW_ONE_CLASSROOM && props.selectedClassroom && (
+        {props.componentMode === MODES.VIEW_ONE_CLASSROOM && (
           <ClassroomForm
+            mode={ClassroomForm.MODES.EDIT}
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
             selectedClassroom={props.selectedClassroom}
           />
         )}
         
-        {props.componentMode === MODES.CREATE_NEW_CLASSROOM && !props.selectedClassroom && (
+        {props.componentMode === MODES.CREATE_NEW_CLASSROOM && (
           <ClassroomForm
+            mode={ClassroomForm.MODES.CREATE}
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
             selectedClassroom={null}

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -62,6 +62,7 @@ class WildCamClassroom extends React.Component {
     
     Actions.wcc_teachers_fetchClassrooms(props.selectedProgram)
     .then(() => {
+      //Transition to: View All Classrooms
       Actions.wildcamClassrooms.resetSelectedClassroom();
       Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ALL_CLASSROOMS);
     });
@@ -91,6 +92,7 @@ class WildCamClassroom extends React.Component {
           <ClassroomsList
             classroomsList={props.classroomsList}
             classroomsStatus={props.classroomsStatus}
+            selectedClassroom={props.selectedClassroom}
           />
         )}
 

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -47,6 +47,8 @@ class WildCamClassroom extends React.Component {
     //Sanity check
     if (!props.selectedProgram) return null;
     
+    console.log('+++ ', props);
+    
     return (
       <Box
         colorIndex="grey-5"

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -60,7 +60,6 @@ class WildCamClassroom extends React.Component {
     .then(() => {
       Actions.wildcamClassrooms.resetSelectedClassroom();
       Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ALL_CLASSROOMS);
-      this.setState({ mode: MODES.VIEW_ALL_CLASSROOMS });
     });
   }
 

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -14,6 +14,7 @@ import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
 
+import ClassroomsList from '../components/ClassroomsList';
 import ClassroomForm from '../components/ClassroomForm';
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
@@ -43,27 +44,23 @@ class WildCamClassroom extends React.Component {
 
   render() {
     const props = this.props;
-    
+
     //Sanity check
     if (!props.selectedProgram) return null;
-    
-    console.log('+++ ', props);
-    
+
     return (
       <Box
         colorIndex="grey-5"
         className="wildcam-classrooms"
       >
-        <Box>
+        <Box pad="medium">
           Classrooms Status: [{props.classroomsStatus}] <br/>
           Classrooms Count: [{props.classroomsList && props.classroomsList.length}]
         </Box>
         
-        <Box>
-          {(props.classroomsList && props.classroomsList.map((item) => {
-            return '???';
-          }))}
-        </Box>
+        <ClassroomsList
+          classroomsList={props.classroomsList}
+        />
         
         <ClassroomForm
           selectedProgram={props.selectedProgram}

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -100,6 +100,7 @@ class WildCamClassroom extends React.Component {
         {props.componentMode === MODES.VIEW_ONE_CLASSROOM && (
           <ClassroomForm
             mode={ClassroomForm.MODES.EDIT}
+            componentMode={props.componentMode}
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
             selectedClassroom={props.selectedClassroom}
@@ -109,6 +110,7 @@ class WildCamClassroom extends React.Component {
         {props.componentMode === MODES.CREATE_NEW_CLASSROOM && (
           <ClassroomForm
             mode={ClassroomForm.MODES.CREATE}
+            componentMode={props.componentMode}
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
             selectedClassroom={null}

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -92,7 +92,7 @@ class WildCamClassroom extends React.Component {
 
         {props.componentMode === MODES.VIEW_ONE_CLASSROOM && (
           <ClassroomForm
-            mode={ClassroomForm.MODES.EDIT}
+            view={ClassroomForm.VIEWS.EDIT}
             componentMode={props.componentMode}
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
@@ -102,7 +102,7 @@ class WildCamClassroom extends React.Component {
         
         {props.componentMode === MODES.CREATE_NEW_CLASSROOM && (
           <ClassroomForm
-            mode={ClassroomForm.MODES.CREATE}
+            view={ClassroomForm.VIEWS.CREATE}
             componentMode={props.componentMode}
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
@@ -115,7 +115,7 @@ class WildCamClassroom extends React.Component {
           <Box>
             Classrooms Status: [{props.classroomsStatus}] <br/>
             Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
-            Mode: {props.componentMode}
+            Component Mode: {props.componentMode}
           </Box>
           <Box>
             <Button

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -14,6 +14,7 @@ import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
+import Toast from 'grommet/components/Toast';
 
 import ClassroomsList from '../components/ClassroomsList';
 import ClassroomForm from '../components/ClassroomForm';
@@ -77,12 +78,15 @@ class WildCamClassroom extends React.Component {
         colorIndex="grey-5"
         className="wildcam-classrooms"
       >
-        <Box pad="medium">
-          Classrooms Status: [{props.classroomsStatus}] <br/>
-          Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
-          Mode: {props.componentMode}
-        </Box>
-
+        {props.toast && props.toast.message && (
+          <Toast
+            status={props.toast.status ? props.toast.status : 'unknown'}
+            onClose={() => { Actions.wildcamClassrooms.resetToast() }}
+          >
+            {props.toast.message}
+          </Toast>
+        )}
+        
         {props.componentMode === MODES.VIEW_ALL_CLASSROOMS && (
           <ClassroomsList
             classroomsList={props.classroomsList}
@@ -107,6 +111,23 @@ class WildCamClassroom extends React.Component {
             selectedClassroom={null}
           />
         )}
+        
+        <Box pad="medium">
+          <h4>Debug Panel</h4>
+          <Box>
+            Classrooms Status: [{props.classroomsStatus}] <br/>
+            Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
+            Mode: {props.componentMode}
+          </Box>
+          <Box>
+            <Button
+              label="Test Toast"
+              onClick={() => {
+                Actions.wildcamClassrooms.setToast({ status: 'ok', message: 'Debug looks good'});
+              }}
+            />
+          </Box>
+        </Box>
 
       </Box>
     );

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -64,6 +64,7 @@ class WildCamClassroom extends React.Component {
         </Box>
         
         <ClassroomForm
+          selectedProgram={props.selectedProgram}
           classroomsStatus={props.classroomsStatus}
           selectedClassroom={props.selectedClassroom}
         />
@@ -74,11 +75,13 @@ class WildCamClassroom extends React.Component {
 
 WildCamClassroom.defaultProps = {
   selectedProgram: PROGRAMS_INITIAL_STATE.selectedProgram,  //Passed from parent.
+  // ----------------
   ...WILDCAMCLASSROOMS_INITIAL_STATE,
 };
 
 WildCamClassroom.propTypes = {
   selectedProgram: PROGRAMS_PROPTYPES.selectedProgram,
+  // ----------------
   ...WILDCAMCLASSROOMS_PROPTYPES,
 };
 

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -42,7 +42,10 @@ class WildCamClassroom extends React.Component {
   }
 
   render() {
-    if (!this.props.selectedProgram) return null;
+    const props = this.props;
+    
+    //Sanity check
+    if (!props.selectedProgram) return null;
     
     return (
       <Box
@@ -50,17 +53,20 @@ class WildCamClassroom extends React.Component {
         className="wildcam-classrooms"
       >
         <Box>
-          Classrooms Status: [{this.props.classroomsStatus}] <br/>
-          Classrooms Count: [{this.props.classroomsList && this.props.classroomsList.length}]
+          Classrooms Status: [{props.classroomsStatus}] <br/>
+          Classrooms Count: [{props.classroomsList && props.classroomsList.length}]
         </Box>
         
         <Box>
-          {(this.props.classroomsList && this.props.classroomsList.map((item) => {
-            return 'aaa';
+          {(props.classroomsList && props.classroomsList.map((item) => {
+            return '???';
           }))}
         </Box>
         
-        <ClassroomForm />
+        <ClassroomForm
+          classroomsStatus={props.classroomsStatus}
+          selectedClassroom={props.selectedClassroom}
+        />
       </Box>
     );
   }

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
+import Button from 'grommet/components/Button';
 import Spinning from 'grommet/components/icons/Spinning';
 
 import ClassroomsList from '../components/ClassroomsList';
@@ -20,6 +21,7 @@ import ClassroomForm from '../components/ClassroomForm';
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
+  WILDCAMCLASSROOMS_COMPONENT_MODE as MODE,
   WILDCAMCLASSROOMS_DATA_STATUS,
   WILDCAMCLASSROOMS_INITIAL_STATE,
   WILDCAMCLASSROOMS_PROPTYPES,
@@ -36,9 +38,6 @@ const MODES = {
 class WildCamClassroom extends React.Component {
   constructor() {
     super();
-    this.state = {
-      mode: MODES.INIT,
-    };
   }
   
   componentDidMount() {
@@ -58,13 +57,13 @@ class WildCamClassroom extends React.Component {
     Actions.wcc_teachers_fetchClassrooms(props.selectedProgram)
     .then(() => {
       Actions.wildcamClassrooms.resetSelectedClassroom();
+      Actions.wildcamClassrooms.setComponentMode(MODES.VIEW_ALL_CLASSROOMS);
       this.setState({ mode: MODES.VIEW_ALL_CLASSROOMS });
     });
   }
 
   render() {
     const props = this.props;
-    const state = this.state;
 
     //Sanity check
     if (!props.selectedProgram) return null;
@@ -77,22 +76,26 @@ class WildCamClassroom extends React.Component {
         <Box pad="medium">
           Classrooms Status: [{props.classroomsStatus}] <br/>
           Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
-          Mode: {this.state.mode}
+          Mode: {props.componentMode}
         </Box>
         
-        {state.mode === MODES.INIT && (
+        <Box pad="medium">
+          <Button>Create new classroom</Button>
+        </Box>
+        
+        {props.componentMode === MODES.INIT && (
           <Box pad="medium">
             <Spinning />
           </Box>
         )}
         
-        {state.mode === MODES.VIEW_ALL_CLASSROOMS && (
+        {props.componentMode === MODES.VIEW_ALL_CLASSROOMS && (
           <ClassroomsList
             classroomsList={props.classroomsList}
           />
         )}
         
-        {state.mode === MODES.VIEW_ONE_CLASSROOM && (
+        {props.componentMode === MODES.VIEW_ONE_CLASSROOM && props.selectedClassroom && (
           <ClassroomForm
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
@@ -100,16 +103,14 @@ class WildCamClassroom extends React.Component {
           />
         )}
         
-        {state.mode === MODES.CREATE_NEW_CLASSROOM && (
+        {props.componentMode === MODES.CREATE_NEW_CLASSROOM && !props.selectedClassroom && (
           <ClassroomForm
             selectedProgram={props.selectedProgram}
             classroomsStatus={props.classroomsStatus}
             selectedClassroom={null}
           />
         )}
-        
-        
-        
+
       </Box>
     );
   }

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -1,8 +1,20 @@
+/*
+WildCam Classrooms
+------------------
+
+The primary component for viewing and managing classrooms and assignments for
+WildCam-type programs/projects.
+
+--------------------------------------------------------------------------------
+ */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
 import Box from 'grommet/components/Box';
+
+import ClassroomForm from '../components/ClassroomForm';
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
@@ -48,7 +60,7 @@ class WildCamClassroom extends React.Component {
           }))}
         </Box>
         
-        
+        <ClassroomForm />
       </Box>
     );
   }

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -22,8 +22,8 @@ import { get, post, put, httpDelete } from '../../../lib/edu-api';
 const WILDCAMCLASSROOMS_COMPONENT_MODES = {
   IDLE: 'idle',  //Initial state. 
   VIEW_ALL_CLASSROOMS: 'view all classrooms',
-  VIEW_ONE_CLASSROOM: 'view all classrooms',
-  CREATE_NEW_CLASSROOM: 'view all classrooms',
+  VIEW_ONE_CLASSROOM: 'view one classroom',
+  CREATE_NEW_CLASSROOM: 'create new classroom',
 };
 
 const WILDCAMCLASSROOMS_DATA_STATUS = {

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -243,13 +243,26 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
         }
       }
  */
-Effect('wcc_teachers_createClassroom', (classroomData) => {
+Effect('wcc_teachers_createClassroom', ({selectedProgram, classroomData}) => {
   //Sanity check
-  if (!classroomData) return;
-  
+  if (!selectedProgram || !classroomData) return;
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+  
+  const requestBody = {
+    data: {
+      attributes: classroomData,
+      relationships: {
+        program: {
+          data: {
+            id: String(selectedProgram.id),
+            type: "programs"
+          }
+        }
+      }
+    }
+  };
 
-  return post('/teachers/classrooms/', { data: classroomData })
+  return post('/teachers/classrooms/', requestBody)
   .then((response) => {
     if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_createClassrooms): No response'; }
     if (response.ok &&

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -321,9 +321,25 @@ Effect('wcc_teachers_editClassroom', ({ selectedClassroom, classroomData }) => {
 
 /*  Deletes a classroom.
  */
-Effect('wcc_teachers_deleteClassroom', (classroomData) => {
+Effect('wcc_teachers_deleteClassroom', (selectedClassroom) => {
+  //Sanity check
+  if (!selectedClassroom) return;
+  
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
   
+  return httpDelete(`/teachers/classrooms/${selectedClassroom.id}`)
+  .then((response) => {
+    if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_deleteClassroom): No response'; }
+    if (response.ok) {
+      return Actions.classrooms.setStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);
+    }
+    throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_deleteClassroom): Invalid response';
+  })
+  .catch((err) => {
+    setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR, err);
+    showErrorMessage(err);
+    throw(err);
+  });
   
 });
 

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -116,8 +116,8 @@ const setClassroomsStatus = (state, classroomsStatus, classroomsStatusDetails = 
   return { ...state, classroomsStatus, classroomsStatusDetails };
 };
 
-const setClassroomsList = (state, setClassroomsList) => {
-  return { ...state, setClassroomsList };
+const setClassroomsList = (state, classroomsList) => {
+  return { ...state, classroomsList };
 };
 
 const setSelectedClassroom = (state, selectedClassroom) => {
@@ -200,13 +200,9 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
  */
 Effect('wcc_teachers_createClassroom', (classroomData) => {
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
-  
-  console.log('+++ wcc_teachers_createClassroom ', classroomData);
-  
+
   return post('/teachers/classrooms/', { data: classroomData })
   .then((response) => {
-    console.log('+++ wcc_teachers_createClassroom response', response);
-    
     if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_createClassrooms): No response'; }
     if (response.ok &&
         response.body && response.body.data) {

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -19,6 +19,13 @@ import { get, post, put, httpDelete } from '../../../lib/edu-api';
 // Constants
 // ---------
 
+const WILDCAMCLASSROOMS_COMPONENT_MODES = {
+  IDLE: 'idle',  //Initial state. 
+  VIEW_ALL_CLASSROOMS: 'view all classrooms',
+  VIEW_ONE_CLASSROOM: 'view all classrooms',
+  CREATE_NEW_CLASSROOM: 'view all classrooms',
+};
+
 const WILDCAMCLASSROOMS_DATA_STATUS = {
   IDLE: 'idle',  //Initial state. 
   FETCHING: 'fetching',  //Fetching classrooms/assignments...
@@ -43,7 +50,9 @@ const WILDCAMCLASSROOMS_DATA_STATUS = {
       };
  */
 const WILDCAMCLASSROOMS_INITIAL_STATE = {
-  classroomsStatus: WILDCAMCLASSROOMS_DATA_STATUS.IDLE,
+  componentMode: WILDCAMCLASSROOMS_COMPONENT_MODES.IDLE,  //The mode of the component, e.g. user is editing a classroom.
+  
+  classroomsStatus: WILDCAMCLASSROOMS_DATA_STATUS.IDLE,  //The status of the data fetch/send.
   classroomsStatusDetails: null,
   
   classroomsList: [],
@@ -72,6 +81,7 @@ const WILDCAMCLASSROOMS_INITIAL_STATE = {
       };
  */
 const WILDCAMCLASSROOMS_PROPTYPES = {
+  componentMode: PropTypes.string,
   classroomsStatus: PropTypes.string,
   classroomsStatusDetails: PropTypes.object,
   classroomsList: PropTypes.array,
@@ -106,10 +116,12 @@ const WILDCAMCLASSROOMS_MAP_STATE = (state, prefix = '') => {
 // Jumpstate Synchronous Actions
 // -----------------------------
 
-const resetClassrooms = (state, classroomsStatus) => {
-  return {
-    ...WILDCAMCLASSROOMS_INITIAL_STATE,
-  };
+const setComponentMode = (state, componentMode) => {
+  return { ...state, componentMode };
+};
+
+const resetClassrooms = (state) => {
+  return { ...WILDCAMCLASSROOMS_INITIAL_STATE };
 };
 
 const setClassroomsStatus = (state, classroomsStatus, classroomsStatusDetails = null) => {
@@ -120,16 +132,16 @@ const setClassroomsList = (state, classroomsList) => {
   return { ...state, classroomsList };
 };
 
-const setSelectedClassroom = (state, selectedClassroom) => {
-  return { ...state, selectedClassroom };
-};
-
 const resetSelectedClassroom = (state) => {
   return {
     ...state,
     selectedClassroom: null,
     //TODO: reset selected assignment as well.
   };
+};
+
+const setSelectedClassroom = (state, selectedClassroom) => {
+  return { ...state, selectedClassroom };
 };
 
 const setToast = (state, message, status) => {
@@ -250,6 +262,7 @@ const wildcamClassrooms = State('wildcamClassrooms', {
   // Initial state
   initial: WILDCAMCLASSROOMS_INITIAL_STATE,
   // Actions
+  setComponentMode,
   resetClassrooms,
   setClassroomsStatus,
   setClassroomsList,
@@ -260,6 +273,7 @@ const wildcamClassrooms = State('wildcamClassrooms', {
 
 export default wildcamClassrooms;
 export {
+  WILDCAMCLASSROOMS_COMPONENT_MODES,
   WILDCAMCLASSROOMS_DATA_STATUS,
   WILDCAMCLASSROOMS_INITIAL_STATE,
   WILDCAMCLASSROOMS_PROPTYPES,

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -27,8 +27,6 @@ const WILDCAMCLASSROOMS_DATA_STATUS = {
   ERROR: 'error',  //Something effed up.
 };
 
-const LOG_PREFIX = 'ducks/wildcam-classrooms';
-
 /*
 --------------------------------------------------------------------------------
  */
@@ -136,7 +134,7 @@ const setToast = (state, message, status) => {
 // Jumpstate Effects
 // -----------------
 // Effects are for async actions and get automatically to the global Actions
-// list.
+// list. NOTE: Effects can only have one argument.
 
 /*  Fetch all the Classrooms for the selected Program from the Education API.
     Implicit: the list of Classrooms is limited to what's available to the

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -72,7 +72,11 @@ const WILDCAMCLASSROOMS_INITIAL_STATE = {
       };
  */
 const WILDCAMCLASSROOMS_PROPTYPES = {
-
+  classroomsStatus: PropTypes.string,
+  classroomsStatusDetails: PropTypes.object,
+  classroomsList: PropTypes.array,
+  selectedClassroom: PropTypes.object,
+  toast: PropTypes.object,
 };
 
 /*  WILDCAMCLASSROOMS_MAP_STATE is used as a convenience feature in
@@ -170,8 +174,49 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
   });
 });
 
+  
+/*  Creates a classroom.
+    
+    API notes:
+      POST /teachers/classrooms/ accepts the following payload structure:
+      {
+        data: {
+          attributes: {
+            name: 'Example 101',
+            subject: 'Exampleology',
+            school: 'University of Example',
+            description: 'An example classroom',
+          },
+          relationships: {
+            program: {
+              data: "1",
+              type: "programs"
+            }
+          }
+        }
+      }
+ */
 Effect('wcc_teachers_createClassroom', (classroomData) => {
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+  
+  console.log('+++ wcc_teachers_createClassroom ', classroomData);
+  
+  return post('/teachers/classrooms/', { data: classroomData })
+  .then((response) => {
+    console.log('+++ wcc_teachers_createClassroom response', response);
+    
+    if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_createClassrooms): No response'; }
+    if (response.ok &&
+        response.body && response.body.data) {
+      Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);
+      return response.body.data;
+    }
+    throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_createClassrooms): Invalid response';
+  })
+  .catch((err) => {
+    setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR, err);
+    showErrorMessage(err);
+  });
 });
 
 Effect('wcc_teachers_editClassroom', (classroomData) => {

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -170,6 +170,18 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
   });
 });
 
+Effect('wcc_teachers_createClassroom', (classroomData) => {
+  Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+});
+
+Effect('wcc_teachers_editClassroom', (classroomData) => {
+  Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+});
+
+Effect('wcc_teachers_deleteClassroom', (classroomData) => {
+  Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+});
+
 /*
 --------------------------------------------------------------------------------
  */

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -34,6 +34,12 @@ const WILDCAMCLASSROOMS_DATA_STATUS = {
   ERROR: 'error',  //Something effed up.
 };
 
+const TEXT = {
+  ERROR: {
+    GENERAL: 'Something went wrong',
+  }
+};
+
 /*
 --------------------------------------------------------------------------------
  */
@@ -121,7 +127,17 @@ const setComponentMode = (state, componentMode) => {
 };
 
 const resetClassrooms = (state) => {
-  return { ...WILDCAMCLASSROOMS_INITIAL_STATE };
+  return {
+    ...state,
+    
+    classroomsStatus: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsStatus,
+    classroomsStatusDetails: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsDetails,
+    
+    classroomsList: WILDCAMCLASSROOMS_INITIAL_STATE.classroomsList,
+    selectedClassroom: WILDCAMCLASSROOMS_INITIAL_STATE.selectedClassroom,
+    
+    //TODO: reset assignments and selected assignments as well.
+  };
 };
 
 const setClassroomsStatus = (state, classroomsStatus, classroomsStatusDetails = null) => {
@@ -257,7 +273,8 @@ Effect('wcc_teachers_deleteClassroom', (classroomData) => {
  */
 
 function showErrorMessage(err) {
-  Actions.notification.setNotification({ status: 'critical', message: 'Something went wrong.' });
+  //Critical Error
+  Actions.notification.setNotification({ status: 'critical', message: TEXT.ERROR.GENERAL });
   console.error(err);
 }
 

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -188,7 +188,9 @@ const resetToast = (state) => {
     logged-in user.
  */
 Effect('wcc_teachers_fetchClassrooms', (program) => {
+  //Sanity check
   if (!program) return;
+  
   const program_id = program.id;
   
   Actions.wildcamClassrooms.resetClassrooms();
@@ -228,7 +230,7 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
             name: 'Example 101',
             subject: 'Exampleology',
             school: 'University of Example',
-            description: 'An example classroom',
+            description: 'An example classroom'
           },
           relationships: {
             program: {
@@ -242,6 +244,9 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
       }
  */
 Effect('wcc_teachers_createClassroom', (classroomData) => {
+  //Sanity check
+  if (!classroomData) return;
+  
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
 
   return post('/teachers/classrooms/', { data: classroomData })
@@ -260,12 +265,50 @@ Effect('wcc_teachers_createClassroom', (classroomData) => {
   });
 });
 
-Effect('wcc_teachers_editClassroom', (classroomData) => {
+/*  Edits a classroom.
+
+    API notes:
+      POST /teachers/classrooms/12345 accepts the following payload structure:
+      {
+        "data": {
+          "attributes": {
+            name: 'Example 101',
+            subject: 'Exampleology',
+            school: 'University of Example',
+            description: 'An example classroom'
+          }
+        }
+      }
+ */
+Effect('wcc_teachers_editClassroom', ({ selectedClassroom, classroomData }) => {
+  //Sanity check
+  if (!selectedClassroom || !classroomData) return;
+  
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+  
+  return put(`/teachers/classrooms/${selectedClassroom.id}`, classroomData)  //NOTE: the put() function requires a different argument format than post().
+  .then((response) => {
+    if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_editClassrooms): No response'; }
+    if (response.ok) {
+      Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);
+      
+      //TODO: Update selectedClassroom
+      return null;
+    }
+    throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_editClassrooms): Invalid response';
+  })
+  .catch((err) => {
+    setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR, err);
+    showErrorMessage(err);
+  });
 });
 
+/*  Deletes a classroom.
+ */
 Effect('wcc_teachers_deleteClassroom', (classroomData) => {
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+  
+  
 });
 
 /*

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -132,6 +132,10 @@ const setClassroomsList = (state, classroomsList) => {
   return { ...state, classroomsList };
 };
 
+const setSelectedClassroom = (state, selectedClassroom) => {
+  return { ...state, selectedClassroom };
+};
+
 const resetSelectedClassroom = (state) => {
   return {
     ...state,
@@ -140,14 +144,17 @@ const resetSelectedClassroom = (state) => {
   };
 };
 
-const setSelectedClassroom = (state, selectedClassroom) => {
-  return { ...state, selectedClassroom };
-};
-
-const setToast = (state, message, status) => {
+const setToast = (state, toast = { message: null, state: null }) => {
   return {
     ...state,
-    toast: { message, status },
+    toast,
+  };
+};
+
+const resetToast = (state) => {
+  return {
+    ...state,
+    toast: { message: null, status: null },
   };
 };
 
@@ -269,6 +276,7 @@ const wildcamClassrooms = State('wildcamClassrooms', {
   setSelectedClassroom,
   resetSelectedClassroom,
   setToast,
+  resetToast,
 });
 
 export default wildcamClassrooms;

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -216,6 +216,7 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
   .catch((err) => {
     setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR, err);
     showErrorMessage(err);
+    throw(err);
   });
 });
 
@@ -275,6 +276,7 @@ Effect('wcc_teachers_createClassroom', ({selectedProgram, classroomData}) => {
   .catch((err) => {
     setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR, err);
     showErrorMessage(err);
+    throw(err);
   });
 });
 
@@ -313,6 +315,7 @@ Effect('wcc_teachers_editClassroom', ({ selectedClassroom, classroomData }) => {
   .catch((err) => {
     setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR, err);
     showErrorMessage(err);
+    throw(err);
   });
 });
 
@@ -324,6 +327,37 @@ Effect('wcc_teachers_deleteClassroom', (classroomData) => {
   
 });
 
+/*  Refreshes the current view by fetching the latest data fromt he server..
+    Called when, e.g. a Classroom is edited, to sync local data with the
+    updated server data.
+ */
+Effect('wcc_teachers_refreshView', ({ program, componentMode, selectedClassroom }) => {
+  //Sanity check
+  if (!program) return;
+  
+  //Save the current view, so we can retrieve it for after the refresh fetch is complete.
+  const saved_selectedClassroom_id = (selectedClassroom) ? selectedClassroom.id : null;
+  
+  //Fetch the latest data...
+  Actions.wcc_teachers_fetchClassrooms(program)
+  .then((classrooms) => {
+    //...then restore the user's previous view.
+    const retrieved_selectedClassroom = (saved_selectedClassroom_id && classrooms)
+      ? classrooms.find((classroom) => { return classroom.id === saved_selectedClassroom_id })
+      : null;
+    
+    Actions.wildcamClassrooms.setComponentMode(componentMode);
+    Actions.wildcamClassrooms.setSelectedClassroom(retrieved_selectedClassroom);
+    //TODO: setSelectedAssignment();
+    
+    return null;
+  })
+  .catch((err) => {
+    setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR, err);
+    showErrorMessage(err);
+    throw(err);
+  });
+});
 /*
 --------------------------------------------------------------------------------
  */

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -189,8 +189,10 @@ Effect('wcc_teachers_fetchClassrooms', (program) => {
           },
           relationships: {
             program: {
-              data: "1",
-              type: "programs"
+              data: {
+                id: "1",
+                type: "programs"
+              }
             }
           }
         }

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -124,6 +124,14 @@ const setSelectedClassroom = (state, selectedClassroom) => {
   return { ...state, selectedClassroom };
 };
 
+const resetSelectedClassroom = (state) => {
+  return {
+    ...state,
+    selectedClassroom: null,
+    //TODO: reset selected assignment as well.
+  };
+};
+
 const setToast = (state, message, status) => {
   return {
     ...state,
@@ -246,6 +254,7 @@ const wildcamClassrooms = State('wildcamClassrooms', {
   setClassroomsStatus,
   setClassroomsList,
   setSelectedClassroom,
+  resetSelectedClassroom,
   setToast,
 });
 

--- a/src/modules/wildcam-map/ducks/index.js
+++ b/src/modules/wildcam-map/ducks/index.js
@@ -45,7 +45,6 @@ const WILDCAMMAP_CAMERA_STATUS = {
 // Initial State / Default Values
 // ------------------------------
 
-
 /*  WILDCAMMAP_INITIAL_STATE defines the default/starting values of the Redux
     store. To use this in your Redux-connected React components, try...
     Usage:
@@ -217,7 +216,8 @@ const setFilterSelectionItem = (state, key, value) => {
 
 // Jumpstate Effects
 // -----------------
-// Effects are for async actions and get automatically to the global Actions list
+// Effects are for async actions and get automatically to the global Actions
+// list. NOTE: Effects can only have one argument.
 
 Effect('wcm_getMapMarkers', (payload = {}) => {
   const mapConfig = payload.mapConfig;

--- a/src/programs/darien/pages/DarienEducators.jsx
+++ b/src/programs/darien/pages/DarienEducators.jsx
@@ -16,18 +16,9 @@ class DarienEducators extends React.Component {
     }
     
     return (
-      <Article colorIndex="accent-3">
-        <Section
-          align="center"
-          colorIndex="accent-3"
-          direction="column"
-          justify="center"
-        >
-          <WildCamClassrooms
-            selectedProgram={this.props.selectedProgram}
-          />
-        </Section>
-      </Article>
+      <WildCamClassrooms
+        selectedProgram={this.props.selectedProgram}
+      />
     );
   }
 };

--- a/src/styles/components/wildcam-classrooms.styl
+++ b/src/styles/components/wildcam-classrooms.styl
@@ -7,3 +7,6 @@ BORDER_SIZE = 0.25rem
     
   .classroom-form
     border: BORDER_SIZE solid TEAL_MID
+
+  .status-box
+    background: TEAL_LIGHT

--- a/src/styles/components/wildcam-classrooms.styl
+++ b/src/styles/components/wildcam-classrooms.styl
@@ -10,3 +10,4 @@ BORDER_SIZE = 0.25rem
 
   .status-box
     background: TEAL_LIGHT
+

--- a/src/styles/components/wildcam-classrooms.styl
+++ b/src/styles/components/wildcam-classrooms.styl
@@ -1,2 +1,7 @@
 .wildcam-classrooms
-  background: #ffe
+
+  .classrooms-list
+    border: 1px solid TEAL_MID
+    
+  .classroom-form
+    border: 1px solid TEAL_MID

--- a/src/styles/components/wildcam-classrooms.styl
+++ b/src/styles/components/wildcam-classrooms.styl
@@ -1,2 +1,2 @@
 .wildcam-classrooms
-  background: #fcf
+  background: #ffe

--- a/src/styles/components/wildcam-classrooms.styl
+++ b/src/styles/components/wildcam-classrooms.styl
@@ -11,3 +11,9 @@ BORDER_SIZE = 0.25rem
   .status-box
     background: TEAL_LIGHT
 
+  .actions-panel
+    display: flex
+    justify-content: center
+    
+    .button
+      margin: 0 0.5em

--- a/src/styles/components/wildcam-classrooms.styl
+++ b/src/styles/components/wildcam-classrooms.styl
@@ -1,7 +1,9 @@
+BORDER_SIZE = 0.25rem
+
 .wildcam-classrooms
 
   .classrooms-list
-    border: 1px solid TEAL_MID
+    border: BORDER_SIZE solid TEAL_MID
     
   .classroom-form
-    border: 1px solid TEAL_MID
+    border: BORDER_SIZE solid TEAL_MID


### PR DESCRIPTION
## PR Overview
This PR follows PR #122 . In this PR, the WildCam-type Program's Classroom management has been rebuilt, with a focus on managing state/view transitions and messaging users.

Major Updates
- The `WildCamClassrooms` component now allows Teachers to create, edit, and delete classrooms.

NOT YET BUILT
- Teachers cannot yet manage students in each Classroom.
- Teachers cannot yet create Assignments (selecting photos from the WildCam Map Explorer) and assign students to them.

### Status
Merging, part 3 coming.