### PR TITLE
WildCam Lab Classrooms - 2018 Rebuild - part 4

### DIFF
--- a/src/ducks/classrooms.js
+++ b/src/ducks/classrooms.js
@@ -171,7 +171,7 @@ Effect('createClassroom', (data) => {
 // Hmm.... Effects can only take one argument?
 Effect('updateClassroom', (data) => {
   Actions.classrooms.setStatus(CLASSROOMS_STATUS.UPDATING);
-  return put(`/teachers/classrooms/${data.id}`, data.payload)
+  return put(`/teachers/classrooms/${data.id}`, { data: { attributes: data.payload } } )
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/classrooms/updateClassroom): No response'; }
       if (response.ok) {

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -274,7 +274,7 @@ Effect('createProgram', (data) => {
 
 Effect('updateProgram', (data) => {
   Actions.programs.setStatus(PROGRAMS_STATUS.UPDATING);
-  return put(`/programs/${data.id}`, data.payload)
+  return put(`/programs/${data.id}`, { data: { attributes: data.payload } })
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/programs/updateProgram): No response'; }
       if (response.ok) {

--- a/src/lib/edu-api.js
+++ b/src/lib/edu-api.js
@@ -29,7 +29,7 @@ export function put(endpoint, data) {
   return superagent.put(`${config.root}${endpoint}`)
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
-    .send({ data: { attributes: data } })
+    .send(data)
     .then(response => response);
 }
 

--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -111,6 +111,7 @@ class AssignmentForm extends React.Component {
     this.state = {
       view: VIEWS.CREATE_NEW,
       form: INITIAL_FORM_DATA,  //Contains basic Assignment data: name, description, etc.
+      formInitialised: false,  //Has initialiseForm() already been run?
       filters: {},
       subjects: [],
       students: [],
@@ -152,6 +153,7 @@ class AssignmentForm extends React.Component {
     
     //Data store update + Redundancy Check (prevent infinite loop, only trigger once)
     if (props.selectedClassroom !== selectedClassroom) {
+      //this.setState({ formInitialised: false });
       Actions.wildcamClassrooms.setSelectedClassroom(selectedClassroom);
     }
     
@@ -166,15 +168,16 @@ class AssignmentForm extends React.Component {
     //WildCam Map Selected Subjects:
     //Check the connection to WildCam Maps to see if the user recently selected
     //Subjects for the Assignment.
-    if (props.wccwcmSelectedSubjects) {
+    if (props.wccwcmSelectedSubjects && props.wccwcmSavedAssignmentState) {
       
-      console.log('+++ props.wccwcmSelectedSubjects: ', props.wccwcmSelectedSubjects.length, this.state);
+      console.log('+++ RESTORING ASSIGNMENT: ', props.wccwcmSavedAssignmentState);
       
       this.setState({
         subjects: props.wccwcmSelectedSubjects,
         filters: props.wccwcmSelectedFilters,
         form: {
           ...this.state.form,
+          ...props.wccwcmSavedAssignmentState,
           classifications_target: props.wccwcmSelectedSubjects.length,
         }
       });
@@ -237,6 +240,12 @@ class AssignmentForm extends React.Component {
   /*  Initialises the classroom form.
    */
   initialiseForm(selectedAssignment) {
+    //Only run this once per page load, thank you.
+    if (this.state.formInitialised) return;
+    this.setState({ formInitialised: true });
+    
+    console.log('+++ INITIALISING FORM');
+    
     if (!selectedAssignment) {
       this.setState({ form: INITIAL_FORM_DATA });
     } else {
@@ -489,6 +498,7 @@ class AssignmentForm extends React.Component {
           filters={state.filters}
           subjects={state.subjects}
           wccwcmMapPath={props.wccwcmMapPath}
+          assignmentStateForSaving={state.form}
         />
         
         {(state.subjects && state.subjects.length > 0) && (

--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -164,32 +164,13 @@ class AssignmentForm extends React.Component {
     } else {
       this.initialise_partTwo(props, classroom_id, assignment_id, props.assignmentsList);
     }
-    
-    //WildCam Map Selected Subjects:
-    //Check the connection to WildCam Maps to see if the user recently selected
-    //Subjects for the Assignment.
-    if (props.wccwcmSelectedSubjects && props.wccwcmSavedAssignmentState) {
-      
-      console.log('+++ RESTORING ASSIGNMENT: ', props.wccwcmSavedAssignmentState);
-      
-      this.setState({
-        subjects: props.wccwcmSelectedSubjects,
-        filters: props.wccwcmSelectedFilters,
-        form: {
-          ...this.state.form,
-          ...props.wccwcmSavedAssignmentState,
-          classifications_target: props.wccwcmSelectedSubjects.length,
-        }
-      });
-      Actions.wildcamMap.resetWccWcmAssignmentData();
-    }
   }
   
   initialise_partTwo(props, classroom_id, assignment_id, assignmentsList) {
     //Create a new assignment
     if (!assignment_id) {  //Note: there should never be assignment_id === 0 or ''
       this.setState({ view: VIEWS.CREATE_NEW });
-      this.initialiseForm(null);
+      this.initialiseForm(props, null);
     
     //Edit an existing assignment... if we can find it.
     } else {
@@ -224,7 +205,7 @@ class AssignmentForm extends React.Component {
         
         //View update
         this.setState({ view: VIEWS.EDIT_EXISTING });
-        this.initialiseForm(selectedAssignment);
+        this.initialiseForm(props, selectedAssignment);
         
       //Otherwise, uh oh.
       } else {
@@ -239,12 +220,10 @@ class AssignmentForm extends React.Component {
   
   /*  Initialises the classroom form.
    */
-  initialiseForm(selectedAssignment) {
+  initialiseForm(props, selectedAssignment) {
     //Only run this once per page load, thank you.
     if (this.state.formInitialised) return;
     this.setState({ formInitialised: true });
-    
-    console.log('+++ INITIALISING FORM');
     
     if (!selectedAssignment) {
       this.setState({ form: INITIAL_FORM_DATA });
@@ -263,6 +242,22 @@ class AssignmentForm extends React.Component {
       });
       this.setState({ form: updatedForm });
     }
+    
+    //WildCam Map Selected Subjects:
+    //Check the connection to WildCam Maps to see if the user recently selected
+    //Subjects for the Assignment.
+    if (props.wccwcmSelectedSubjects && props.wccwcmSavedAssignmentState) {
+      this.setState({
+        subjects: props.wccwcmSelectedSubjects,
+        filters: props.wccwcmSelectedFilters,
+        form: {
+          ...this.state.form,
+          ...props.wccwcmSavedAssignmentState,
+          classifications_target: props.wccwcmSelectedSubjects.length,
+        }
+      });
+      Actions.wildcamMap.resetWccWcmAssignmentData();
+    }
   }
   
   // ----------------------------------------------------------------
@@ -273,7 +268,6 @@ class AssignmentForm extends React.Component {
     //Special case: classificatons_target
     //The number of Classfications a Student needs to do cannot exceed the amount of Subjects selected.
     if (e.target.id === 'classifications_target') {
-      console.log('+++ classifications_target: ', val);
       let maxVal = (this.state.subjects) ? this.state.subjects.length : 0;
       val = parseInt(val);
       if (isNaN(val)) val = 0;
@@ -294,8 +288,6 @@ class AssignmentForm extends React.Component {
   }
   
   submitForm(e) {
-    console.log('+++ AssignmentForm.submitForm() ', this.props);
-    
     const props = this.props;
     const state = this.state;
     
@@ -305,8 +297,6 @@ class AssignmentForm extends React.Component {
     //Sanity check
     if (!props.selectedProgram) return;
     if (!props.selectedClassroom) return;
-    
-    console.log('+++ AssignmentForm.submitForm() A');
     
     //Submit Form: create new assignment
     if (state.view === VIEWS.CREATE_NEW) {
@@ -339,8 +329,6 @@ class AssignmentForm extends React.Component {
     
     //Submit Form: update existing classroom
     } else if (state.view === VIEWS.EDIT_EXISTING) {
-      console.log('+++ AssignmentForm.submitForm() B');
-      
       const filters = (state.filters) ? state.filters : {};
       const subjects = (state.subjects)
         ? state.subjects.map(sub => sub.subject_id)

--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -76,7 +76,9 @@ const TEXT = {
   },
   ASSIGNMENT_FORM: {
     NAME: 'Assignment name',
-    DESCRIPTION: 'Instructions for Students',
+    DESCRIPTION: 'Instructions for students',
+    CLASSIFICATIONS_TARGET: 'Classifications target',
+    DUEDATE: 'Due date',
   },
   ERROR: {
     GENERAL: 'Something went wrong',
@@ -91,6 +93,8 @@ const TEXT = {
 const INITIAL_FORM_DATA = {
   name: '',
   description: '',
+  classifications_target: '',
+  duedate: '',
 };
 
 /*
@@ -227,9 +231,16 @@ class AssignmentForm extends React.Component {
       const originalForm = INITIAL_FORM_DATA;
       const updatedForm = {};
       Object.keys(originalForm).map((key) => {
-        updatedForm[key] = (selectedAssignment && selectedAssignment[key])
-          ? selectedAssignment[key]
-          : originalForm[key];
+        //The structure for Assignments is weird.
+        if (selectedAssignment && selectedAssignment.metadata && selectedAssignment.metadata[key]) {
+          updatedForm[key] = selectedAssignment.metadata[key];
+        } else if (selectedAssignment && selectedAssignment.attributes && selectedAssignment.attributes[key]) {
+          updatedForm[key] = selectedAssignment.attributes[key];
+        } else {
+          updatedForm[key] = originalForm[key];
+        }
+        
+        
       });
       this.setState({ form: updatedForm });
     }
@@ -427,6 +438,27 @@ class AssignmentForm extends React.Component {
               id="description"
               value={this.state.form.description}
               onChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
+        
+        <fieldset>
+          <FormField htmlFor="name" label={TEXT.ASSIGNMENT_FORM.CLASSIFICATIONS_TARGET}>
+            <TextInput
+              id="classifications_target"
+              required={true}
+              value={this.state.form.classifications_target}
+              onDOMChange={this.updateForm.bind(this)}
+            />
+          </FormField>
+        </fieldset>
+        
+        <fieldset>
+          <FormField htmlFor="name" label={TEXT.ASSIGNMENT_FORM.DUEDATE}>
+            <TextInput
+              id="duedate"
+              value={this.state.form.duedate}
+              onDOMChange={this.updateForm.bind(this)}
             />
           </FormField>
         </fieldset>

--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -127,7 +127,6 @@ class AssignmentForm extends React.Component {
         .../classrooms/123/assignments/456 - edit assignment 456 (i.e. assignment_id=456 supplied.)
    */
   initialise(props = this.props) {
-    console.log('+++ initialise: ');
     const state = this.state;
     
     const classroom_id = (props.match && props.match.params)
@@ -158,7 +157,6 @@ class AssignmentForm extends React.Component {
     
     //Check the connection to WildCam Maps: if the user recently selected
     //Subjects for the Assignment, respect it.
-    console.log('+++ props.wccwcmSelectedSubjects: ', props.wccwcmSelectedSubjects);
     if (props.wccwcmSelectedSubjects) {
       this.setState({
         subjects: props.wccwcmSelectedSubjects,
@@ -188,7 +186,6 @@ class AssignmentForm extends React.Component {
         
         //Also extract initial subjects and filters used by the Assignment
         if (!this.state.subjects || this.state.subjects.length === 0) {
-          console.log('+++ selectedAssignment: ', selectedAssignment);
           const newSubjects = (selectedAssignment.metadata && selectedAssignment.metadata.subjects)
             ? selectedAssignment.metadata.subjects.map((subject) => {
                 return {
@@ -254,6 +251,8 @@ class AssignmentForm extends React.Component {
   }
   
   submitForm(e) {
+    console.log('+++ AssignmentForm.submitForm() ', this.props);
+    
     const props = this.props;
     const state = this.state;
     
@@ -263,6 +262,8 @@ class AssignmentForm extends React.Component {
     //Sanity check
     if (!props.selectedProgram) return;
     if (!props.selectedClassroom) return;
+    
+    console.log('+++ AssignmentForm.submitForm() A');
     
     //Submit Form: create new assignment
     if (state.view === VIEWS.CREATE_NEW) {
@@ -295,6 +296,8 @@ class AssignmentForm extends React.Component {
     
     //Submit Form: update existing classroom
     } else if (state.view === VIEWS.EDIT_EXISTING) {
+      console.log('+++ AssignmentForm.submitForm() B');
+      
       const filters = (state.filters) ? state.filters : {};
       const subjects = (state.subjects)
         ? state.subjects.map(sub => sub.subject_id)
@@ -305,7 +308,7 @@ class AssignmentForm extends React.Component {
         assignmentData: state.form,
         filters,
         subjects,
-        students: state.students,        
+        students: state.students,
       }).then(() => {
         //Message
         Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.ASSIGNMENT_EDITED, status: 'ok' });

--- a/src/modules/wildcam-classrooms/components/StudentsList.jsx
+++ b/src/modules/wildcam-classrooms/components/StudentsList.jsx
@@ -128,7 +128,7 @@ class StudentsList extends React.Component {
     return (
       <Box
         className="students-list"
-        margin="small"
+        margin={{ horizontal: "none", vertical: "small" }}
         pad="small"
       >
         <Heading tag="h3">{TEXT.HEADINGS.STUDENTS}</Heading>

--- a/src/modules/wildcam-classrooms/components/SubjectsList.jsx
+++ b/src/modules/wildcam-classrooms/components/SubjectsList.jsx
@@ -124,12 +124,10 @@ class SubjectsList extends React.Component {
               className="button"
               label={TEXT.ACTIONS.SELECT_SUBJECTS}
               onClick={() => {
-                //Save the return path
+                //Save the return path, assignment state, and the initial filters to be used by the map.
                 Actions.wildcamMap.setWccWcmAssignmentPath(props.location.pathname);
-                
-                //Save the assignment state
-                console.log('+++ SAVING: ', props.assignmentStateForSaving);
                 Actions.wildcamMap.setWccWcmSavedAssignmentState(props.assignmentStateForSaving);
+                if (props.filters) Actions.wildcamMap.setFilters(props.filters);
                 
                 //Transition to: WildCam Map
                 props.history.push(props.wccwcmMapPath);

--- a/src/modules/wildcam-classrooms/components/SubjectsList.jsx
+++ b/src/modules/wildcam-classrooms/components/SubjectsList.jsx
@@ -127,6 +127,10 @@ class SubjectsList extends React.Component {
                 //Save the return path
                 Actions.wildcamMap.setWccWcmAssignmentPath(props.location.pathname);
                 
+                //Save the assignment state
+                console.log('+++ SAVING: ', props.assignmentStateForSaving);
+                Actions.wildcamMap.setWccWcmSavedAssignmentState(props.assignmentStateForSaving);
+                
                 //Transition to: WildCam Map
                 props.history.push(props.wccwcmMapPath);
               }}
@@ -198,6 +202,7 @@ class SubjectsList extends React.Component {
 SubjectsList.defaultProps = {
   filters: null,
   subjects: [],
+  assignmentStateForSaving: null,
   // ----------------
   ...WILDCAMCLASSROOMS_INITIAL_STATE,
   ...WILDCAMMAP_INITIAL_STATE,
@@ -206,6 +211,7 @@ SubjectsList.defaultProps = {
 SubjectsList.propTypes = {
   filters: PropTypes.object,
   subjects: PropTypes.array,
+  assignmentStateForSaving: PropTypes.object,
   // ----------------
   ...WILDCAMCLASSROOMS_PROPTYPES,
   ...WILDCAMMAP_PROPTYPES,

--- a/src/modules/wildcam-classrooms/components/SubjectsList.jsx
+++ b/src/modules/wildcam-classrooms/components/SubjectsList.jsx
@@ -154,7 +154,17 @@ class SubjectsList extends React.Component {
           return Object.keys(props.filters).map((key, index) => {
             const val = props.filters[key];
             return (
-              <div key={`subjects-list-filter_${index}`}>{key} : {val}</div>
+              <div key={`subjects-list-filter_${index}`}>{key} : {(()=>{
+                if (Array.isArray(val, index)) {
+                  let output = '';
+                  val.map((v) => {
+                    output += ((output !== '') ? ', ' : '' ) + v;
+                  });
+                  return output;
+                } else {
+                  return val;
+                }
+              })()}</div>
             );
           });
         })()}

--- a/src/modules/wildcam-classrooms/components/SubjectsList.jsx
+++ b/src/modules/wildcam-classrooms/components/SubjectsList.jsx
@@ -105,7 +105,7 @@ class SubjectsList extends React.Component {
     return (
       <Box
         className="subjects-list"
-        margin="small"
+        margin={{ horizontal: "none", vertical: "small" }}
         pad="small"
       >
         <Heading tag="h3">{TEXT.HEADINGS.SUBJECTS}</Heading>

--- a/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamClassrooms.jsx
@@ -106,16 +106,6 @@ class WildCamClassroom extends React.Component {
           />
           <Route path="*" component={Status404} />
         </Switch>
-        
-        <Box pad="medium">
-          <h4>Debug Panel</h4>
-          <Box>
-            Classrooms Status: [{props.classroomsStatus}] <br/>
-            Classrooms Count: [{props.classroomsList && props.classroomsList.length}] <br/>
-            Assignments Status: [{props.assignmentsStatus}] <br/>
-            Assignments Count: [{props.assignmentsList && props.assignmentsList.length}] <br/>
-          </Box>
-        </Box>
 
       </Box>
     );

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -647,17 +647,9 @@ Effect('wcc_teachers_createAssignment', ({ selectedProgram, selectedClassroom, a
  */
 Effect('wcc_editAssignment', ({ selectedAssignment, assignmentData, students = [], filters = {}, subjects = [] }) => {
   //Sanity check
-  console.log('+++ wcc_editAssignment A: ', selectedAssignment, assignmentData);
-  
-  console.log('+++ wcc_editAssignment B: ', (!selectedAssignment || !assignmentData));
-  
   if (!selectedAssignment || !assignmentData) return;
   
-  console.log('+++ wcc_editAssignment C');
-  
   Actions.wildcamClassrooms.setAssignmentsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
-  
-  console.log('+++ wcc_editAssignment D');
   
   const requestBody = {
     data: {
@@ -684,12 +676,8 @@ Effect('wcc_editAssignment', ({ selectedAssignment, assignmentData, students = [
     }
   };
   
-  console.log('+++ wcc_editAssignment E');
-  
   return put(`/assignments/${selectedAssignment.id}`, requestBody)
   .then((response) => {
-    console.log('+++ wcc_editAssignment F: ', response);
-    
     if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_editClassrooms): No response'; }
     if (response.ok) {
       Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -357,7 +357,7 @@ Effect('wcc_teachers_editClassroom', ({ selectedClassroom, classroomData }) => {
   
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
   
-  return put(`/teachers/classrooms/${selectedClassroom.id}`, classroomData)  //NOTE: the put() function requires a different argument format than post().
+  return put(`/teachers/classrooms/${selectedClassroom.id}`, { data: { attributes: classroomData } })
   .then((response) => {
     if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_editClassrooms): No response'; }
     if (response.ok) {
@@ -647,9 +647,17 @@ Effect('wcc_teachers_createAssignment', ({ selectedProgram, selectedClassroom, a
  */
 Effect('wcc_editAssignment', ({ selectedAssignment, assignmentData, students = [], filters = {}, subjects = [] }) => {
   //Sanity check
+  console.log('+++ wcc_editAssignment A: ', selectedAssignment, assignmentData);
+  
+  console.log('+++ wcc_editAssignment B: ', (!selectedAssignment || !assignmentData));
+  
   if (!selectedAssignment || !assignmentData) return;
   
+  console.log('+++ wcc_editAssignment C');
+  
   Actions.wildcamClassrooms.setAssignmentsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);
+  
+  console.log('+++ wcc_editAssignment D');
   
   const requestBody = {
     data: {
@@ -676,8 +684,12 @@ Effect('wcc_editAssignment', ({ selectedAssignment, assignmentData, students = [
     }
   };
   
-  return put(`/assignments/${selectedAssignment.id}`, assignmentData)  //NOTE: the put() function requires a different argument format than post().
+  console.log('+++ wcc_editAssignment E');
+  
+  return put(`/assignments/${selectedAssignment.id}`, requestBody)
   .then((response) => {
+    console.log('+++ wcc_editAssignment F: ', response);
+    
     if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_editClassrooms): No response'; }
     if (response.ok) {
       Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);

--- a/src/modules/wildcam-map/containers/MapControls.jsx
+++ b/src/modules/wildcam-map/containers/MapControls.jsx
@@ -74,7 +74,10 @@ class MapControls extends React.Component {
 
     return (
       <Box className="map-controls">
-        <Accordion openMulti={true}>
+        <Accordion
+          openMulti={true}
+          active={(this.props.wccwcmAssignmentPath) ? [0] : null}
+        >
           <AccordionPanel heading={statusMessage} className="map-controls-status">
             <SuperDownloadButton
               fileNameBase="wildcam-"
@@ -87,7 +90,7 @@ class MapControls extends React.Component {
               direction="row"
               pad="small"
               colorIndex="light-2"
-              margin="small"
+              margin={{ horizontal: "small", vertical: "none" }}
               align="center"
               alignContent="between"
               separator="horizontal"
@@ -110,7 +113,7 @@ class MapControls extends React.Component {
                 className="wccwcm-connector"
                 direction="column"
                 pad="small"
-                margin="small"
+                margin={{ horizontal: "small", vertical: "none" }}
                 align="center"
                 alignContent="between"
               >

--- a/src/modules/wildcam-map/ducks/index.js
+++ b/src/modules/wildcam-map/ducks/index.js
@@ -185,6 +185,10 @@ const setActiveCameraDataStatus = (state, activeCameraDataStatus) => {
   return { ...state, activeCameraDataStatus };
 };
 
+const setFilters = (state, filters) => {
+  return { ...state, filters };
+};
+
 /*  Adds to a multi-choice filter selection.
  */
 const addFilterSelectionItem = (state, item) => {
@@ -392,6 +396,7 @@ const wildcamMap = State('wildcamMap', {
   setActiveCameraMetadataStatus,
   setActiveCameraData,
   setActiveCameraDataStatus,
+  setFilters,
   addFilterSelectionItem,
   removeFilterSelectionItem,
   setFilterSelectionItem,

--- a/src/modules/wildcam-map/ducks/index.js
+++ b/src/modules/wildcam-map/ducks/index.js
@@ -70,6 +70,7 @@ const WILDCAMMAP_INITIAL_STATE = {
   //Connection between WildCam Classroom and WildCam Map
   wccwcmMapPath: '',  //The URL/path that the Teacher is taken to when they click on "Select subject" in the WildCam Classroom - Create Assignment stage. Must be registered early on in the Program.
   wccwcmAssignmentPath: '',  //The URL/path that the Teacher is returned to when they finally finish selecting subjects on the WildCam Map.
+  wccwcmSavedAssignmentState: null,
   wccwcmSelectedSubjects: null,
   wccwcmSelectedFilters: null,
 };
@@ -105,6 +106,7 @@ const WILDCAMMAP_PROPTYPES = {
   
   wccwcmMapPath: PropTypes.string,
   wccwcmAssignmentPath: PropTypes.string,
+  wccwcmSavedAssignmentState: PropTypes.object,
   wccwcmSelectedSubjects: PropTypes.array,
   wccwcmSelectedFilters: PropTypes.object,
 };
@@ -229,6 +231,7 @@ const resetWccWcmAssignmentData = (state) => {
     ...state,
     //Maintain the Map Path, however
     wccwcmAssignmentPath: WILDCAMMAP_INITIAL_STATE.wccwcmAssignmentPath,
+    wccwcmSavedAssignmentState: WILDCAMMAP_INITIAL_STATE.wccwcmSavedAssignmentState,
     wccwcmSelectedSubjects: WILDCAMMAP_INITIAL_STATE.wccwcmSelectedSubjects,
     wccwcmSelectedFilters: WILDCAMMAP_INITIAL_STATE.wccwcmSelectedFilters,
   }
@@ -238,6 +241,9 @@ const setWccWcmMapPath = (state, wccwcmMapPath) => {
 }
 const setWccWcmAssignmentPath = (state, wccwcmAssignmentPath) => {
   return { ...state, wccwcmAssignmentPath };
+}
+const setWccWcmSavedAssignmentState = (state, wccwcmSavedAssignmentState) => {
+  return { ...state, wccwcmSavedAssignmentState };
 }
 const setWccWcmSelectedSubjects = (state, wccwcmSelectedSubjects) => {
   return { ...state, wccwcmSelectedSubjects };
@@ -392,6 +398,7 @@ const wildcamMap = State('wildcamMap', {
   resetWccWcmAssignmentData,
   setWccWcmMapPath,
   setWccWcmAssignmentPath,
+  setWccWcmSavedAssignmentState,
   setWccWcmSelectedSubjects,
   setWccWcmSelectedFilters,
 });

--- a/src/programs/darien/DarienProgram.jsx
+++ b/src/programs/darien/DarienProgram.jsx
@@ -22,35 +22,44 @@ import Status401 from '../../components/common/Status401';
 import Status404 from '../../components/common/Status404';
 import GenericStatusPage from '../../components/common/GenericStatusPage';
 
-function DarienProgram(props) {
-  if (!props.initialised) {  //User status unknown: wait.
-    return (<GenericStatusPage status="fetching" message="Loading..." />);
-  } else if (!props.selectedProgram) {  //Anomaly: program status not set.
-    //Users should _not_ see this, but might due to weird lifecycle/timing issues.
-    return (<GenericStatusPage status="fetching" message="Loading Program..." />);
-  } else {
-    
+class DarienProgram extends React.Component {
+  constructor() {
+    super();
+  }
+  
+  componentWillReceiveProps(props = this.props) {
     //Register the connection between the WildCam Classrooms and the WildCam Maps.
     Actions.wildcamMap.setWccWcmMapPath(`${props.match.url}/map`);
+  }
 
-    if (props.user) {  //User logged in: give access to all locations.
-      return (
-        <Switch>
-          <Route exact path={`${props.match.url}/`} component={DarienHome} />
-          <Route path={`${props.match.url}/educators`} component={DarienEducators} />
-          <Route path={`${props.match.url}/map`} component={DarienMap} />
-          <Route path="*" component={Status404} />
-        </Switch>
-      );
-    } else {  //User not logged in: give limited access.
-      return (
-        <Switch>
-          <Route exact path={`${props.match.url}/`} component={DarienHome} />
-          <Route path={`${props.match.url}/educators`} component={Status401} />
-          <Route path={`${props.match.url}/map`} component={DarienMap} />
-          <Route path="*" component={Status404} />
-        </Switch>
-      );
+  render() {
+    const props = this.props;
+    
+    if (!props.initialised) {  //User status unknown: wait.
+      return (<GenericStatusPage status="fetching" message="Loading..." />);
+    } else if (!props.selectedProgram) {  //Anomaly: program status not set.
+      //Users should _not_ see this, but might due to weird lifecycle/timing issues.
+      return (<GenericStatusPage status="fetching" message="Loading Program..." />);
+    } else {
+      if (props.user) {  //User logged in: give access to all locations.
+        return (
+          <Switch>
+            <Route exact path={`${props.match.url}/`} component={DarienHome} />
+            <Route path={`${props.match.url}/educators`} component={DarienEducators} />
+            <Route path={`${props.match.url}/map`} component={DarienMap} />
+            <Route path="*" component={Status404} />
+          </Switch>
+        );
+      } else {  //User not logged in: give limited access.
+        return (
+          <Switch>
+            <Route exact path={`${props.match.url}/`} component={DarienHome} />
+            <Route path={`${props.match.url}/educators`} component={Status401} />
+            <Route path={`${props.match.url}/map`} component={DarienMap} />
+            <Route path="*" component={Status404} />
+          </Switch>
+        );
+      }
     }
   }
 }

--- a/src/styles/components/wildcam-map.styl
+++ b/src/styles/components/wildcam-map.styl
@@ -40,6 +40,9 @@
       &.selected
         background: TEAL_LIGHT
     
+    .wccwcm-connector
+      border: 1px solid GREY_5
+    
     .zooniversal-translator
       .selected
         background: TEAL_LIGHT


### PR DESCRIPTION
## PR Overview
This PR follows #124. In this PR, we're mostly concerned with fixing bugs that prevent the Teachers from fully enjoying the Create/Edit WildCam Assignments functionality.

Updates in place:
- You can actually edit WildCam Assignments. There was a bug previously that prevented data from being saved on an update. (Create Assignment continues to work fine.)

Planned updates:
- The Assignment form should remember any data the user type into the form before they transition to the Map (to select Subjects). At this moment, if you type in an Assignment name, select subjects, then return, the Assignment name just goshdarn disappears/resets to the original.

### Important: Changes Affecting Astro Classrooms
@srallen please be aware that I've updated the `/lib/edu-api.js`'s `put()` function, since the pre-built request body structure wasn't flexible enough to support WildCam Classroom's PUT requests (i.e. I needed to edit the Relationship field as well as the Attributes field).

The changes are as follows:
- `src/lib/edu-api.js`: `put()` function no longer _implicitly_ constructs the request body structure.
- `src/ducks/classrooms.js`: `put()` call now _explicitly_ constructs the request body structure. Affects I2A's Edit Classroom functionality.
- `src/ducks/programs.js`. ditto. Affects... er, nothing, at the moment.

#### Side note
Sarah, since you mentioned you were making updates to I2A classrooms for summer, here are some useful notes, so you have fewer worries about your updates crossing with WildCam's functionality.
- Almost all the WildCam code has been moved to `src/modules/` and `src/programs/`.
  - they don't use any I2A Classroom/Assignment-specific code; so `src/ducks/classrooms.js` and `src/containers/AssignmentFormContainer.jsx`, for example, are safe to update for I2A.
- Only a few links to the shared code remains:
  - WildCam Classrooms still relies on the shared Join page.
    - NOTE: the Join page doesn't seem to auto-redirect students to their respective classrooms/assignments, although the join is still registered; this redirection issue seems to be present even at v1.0.0, but I haven't tested/debugged to be sure.
  - Common components like SuperDownloadButton and Status404 are still in shared use.
  - The "index" pages (src/ducks/reducer.js, ProgramHomeContainer) still have specific references to the Darien code.

### Status
WIP for WildCam Darien stuff.

The changes `/lib/edu-api.js` and its dependents are ready for review, @srallen .