### PR TITLE
WildCam Lab Classrooms - 2018 Rebuild - part 5

### DIFF
--- a/src/programs/darien/DarienProgram.jsx
+++ b/src/programs/darien/DarienProgram.jsx
@@ -15,9 +15,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 import { Switch, Route } from 'react-router-dom';
+
 import DarienHome from './pages/DarienHome';
 import DarienEducators from './pages/DarienEducators';
 import DarienMap from './pages/DarienMap';
+
+import DarienInfoEcology from './pages/info/DarienInfoEcology';
+
 import Status401 from '../../components/common/Status401';
 import Status404 from '../../components/common/Status404';
 import GenericStatusPage from '../../components/common/GenericStatusPage';
@@ -45,6 +49,9 @@ class DarienProgram extends React.Component {
         return (
           <Switch>
             <Route exact path={`${props.match.url}/`} component={DarienHome} />
+            
+            <Route exact path={`${props.match.url}/educators/ecology`} component={DarienInfoEcology} />
+            
             <Route path={`${props.match.url}/educators`} component={DarienEducators} />
             <Route path={`${props.match.url}/map`} component={DarienMap} />
             <Route path="*" component={Status404} />

--- a/src/programs/darien/common/DarienNavi.jsx
+++ b/src/programs/darien/common/DarienNavi.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Anchor from 'grommet/components/Anchor';
+import Box from 'grommet/components/Box';
+
+import ShareIcon from 'grommet/components/icons/base/Share';
+
+function DarienNavi(props) {
+  return (
+    <Box
+      className="program-navi"
+      direction="row"
+      pad="small"
+    >
+      <Anchor className="big link" path={`/wildcam-darien-lab`}>WildCam Darien Labs</Anchor>
+      <Anchor className="link" path={`/wildcam-darien-lab/educators`}>Classrooms</Anchor>
+      <Anchor className="link" path={`/wildcam-darien-lab/educators/ecology`}>Ecology</Anchor>
+      <Anchor className="external link" href="https://www.hhmi.org/biointeractive/wildcam-darien" target="_blank" rel="noopener noreferrer">HHMI <ShareIcon size="xsmall" /></Anchor>
+      <Anchor className="external link" href="https://www.zooniverse.org/projects/wildcam/wildcam-darien" target="_blank" rel="noopener noreferrer">Zooniverse <ShareIcon size="xsmall" /></Anchor>
+    </Box>
+  );
+};
+
+DarienNavi.defaultProps = {};
+DarienNavi.propTypes = {};
+
+export default DarienNavi;

--- a/src/programs/darien/pages/DarienEducators.jsx
+++ b/src/programs/darien/pages/DarienEducators.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
 import WildCamClassrooms from '../../../modules/wildcam-classrooms/containers/WildCamClassrooms';
+import DarienNavi from '../common/DarienNavi';
 
 import Article from 'grommet/components/Article';
 import Box from 'grommet/components/Box';
@@ -16,12 +17,16 @@ class DarienEducators extends React.Component {
     }
     
     return (
-      <WildCamClassrooms
-        selectedProgram={this.props.selectedProgram}
-        location={this.props.match}
-        history={this.props.history}
-        match={this.props.match}
-      />
+      <Box>
+        <DarienNavi />
+        <WildCamClassrooms
+          key="dariem-wildcamclassrooms"
+          selectedProgram={this.props.selectedProgram}
+          location={this.props.match}
+          history={this.props.history}
+          match={this.props.match}
+        />
+      </Box>
     );
   }
 };

--- a/src/programs/darien/pages/DarienHome.jsx
+++ b/src/programs/darien/pages/DarienHome.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
 import Section from 'grommet/components/Section';
+import Anchor from 'grommet/components/Anchor';
 import Box from 'grommet/components/Box';
 import Hero from 'grommet/components/Hero';
 import Image from 'grommet/components/Image';
@@ -13,7 +14,6 @@ import Paragraph from 'grommet/components/Paragraph';
 import Label from 'grommet/components/Label';
 
 import ProgramHome from '../../../components/common/ProgramHome';
-import NeedHelp from '../../../components/common/NeedHelp';
 
 import {
   PROGRAMS_INITIAL_STATE, PROGRAMS_PROPTYPES, PROGRAMS_STATUS
@@ -61,7 +61,19 @@ function DarienHome(props) {
           </Box>
         </Box>
       </Section>
-      <NeedHelp />
+      {/*
+      //WildCam Darien Lab's specific version of <NeedHelp />
+      //----------------
+      */}
+      <Section className="home__section" align="center" colorIndex="accent-2">
+        <Paragraph className="section__paragraph" align="center">
+          Need help? Have questions?<br />
+          Check out the <Anchor href="https://www.zooniverse.org/projects/wildcam/wildcam-darien/talk/843">WildCam Darien Talk Board</Anchor> or <Anchor href="mailto:collab@zooniverse.org">email us</Anchor>
+        </Paragraph>
+      </Section>
+      {/*
+      //----------------
+      */}
     </ProgramHome>
   );
 }

--- a/src/programs/darien/pages/info/DarienInfoEcology.jsx
+++ b/src/programs/darien/pages/info/DarienInfoEcology.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import DarienNavi from '../../common/DarienNavi';
+
+import Box from 'grommet/components/Box';
+
+function DarienInfoEcology(props) {
+  return (
+    <Box>
+      <DarienNavi />
+      <Box className="wildcam-info-page">
+        ECOLOGY
+      </Box>
+    </Box>
+  );
+};
+
+DarienInfoEcology.defaultProps = {};
+
+DarienInfoEcology.propTypes = {};
+
+export default DarienInfoEcology;

--- a/src/programs/darien/pages/info/DarienInfoEcology.jsx
+++ b/src/programs/darien/pages/info/DarienInfoEcology.jsx
@@ -4,13 +4,28 @@ import PropTypes from 'prop-types';
 import DarienNavi from '../../common/DarienNavi';
 
 import Box from 'grommet/components/Box';
+import Heading from 'grommet/components/Heading';
+import Image from 'grommet/components/Image';
+import Paragraph from 'grommet/components/Paragraph';
 
 function DarienInfoEcology(props) {
   return (
     <Box>
       <DarienNavi />
-      <Box className="wildcam-info-page">
-        ECOLOGY
+      <Box
+        className="wildcam-info-page"
+        pad={{ vertical: 'medium', horizontal: 'large' }}
+      >
+        <Heading tag="h2">Ecology</Heading>
+        <Image src="https://placeimg.com/400/250/nature" size="large" />
+        <Paragraph>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec pellentesque pellentesque egestas. In vitae convallis mauris. Mauris vitae dapibus nunc. Mauris porttitor elit ac elit ultricies, id maximus eros efficitur. Integer lacus turpis, dapibus quis mi et, facilisis condimentum nulla. Vestibulum venenatis turpis eu mi mollis, id viverra erat ultrices. Maecenas et tristique diam. Pellentesque at eros sit amet massa sodales facilisis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla a justo neque. Vestibulum id faucibus sapien, sed laoreet tortor. Quisque eget purus libero. Donec scelerisque velit ac erat tristique sagittis. Donec id urna at quam hendrerit imperdiet sed eleifend nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Phasellus ac maximus orci.</Paragraph>
+        <Paragraph>Aliquam consequat et odio ut vehicula. Cras nec hendrerit nisl. Curabitur tincidunt enim feugiat sapien volutpat eleifend non non massa. Phasellus vel dictum velit. Proin imperdiet, sem lacinia cursus vestibulum, urna est dictum massa, ac ultricies tellus libero sodales purus. Aenean luctus gravida tortor, sit amet pulvinar libero varius sit amet. Proin ante purus, mollis id lobortis ut, consequat interdum eros. Duis lacinia urna ac ex rutrum laoreet. Nam ac tincidunt tellus, ultricies sodales nibh. Sed pulvinar diam id auctor ultricies. Donec porta sed mauris a luctus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae;</Paragraph>
+        <Image src="https://placeimg.com/400/250/animals" caption="Example caption 1" alt="Example image 1" size="large" />
+        <Paragraph>Sed sed cursus tortor, efficitur lobortis eros. Vestibulum orci tortor, posuere eget augue vitae, dictum ultricies ipsum. Duis id tempor mauris, et consectetur turpis. Aliquam quis tempor tellus, ut semper diam. Duis in bibendum ex. In ut nunc dolor. Mauris et dolor ex. Praesent rutrum ultricies arcu dictum convallis. Curabitur ut magna quis velit tincidunt tincidunt at nec dolor. Donec pharetra ultricies odio at ullamcorper. Suspendisse potenti. Sed ut faucibus enim. Suspendisse potenti. Phasellus et metus pulvinar, sagittis urna sed, lacinia libero. Quisque gravida, mauris eget accumsan scelerisque, mauris felis tempus neque, in tempus purus lectus ut arcu.</Paragraph>
+        <Paragraph>Curabitur convallis gravida imperdiet. Vivamus at lectus lacinia, volutpat dolor imperdiet, dignissim risus. Nunc faucibus posuere turpis quis condimentum. Suspendisse mattis ex vel arcu pellentesque blandit. Quisque vestibulum ligula dolor, eget luctus arcu ultrices vitae. Ut sed magna vulputate, semper lorem vel, iaculis odio. Nunc malesuada tellus ipsum, at congue nibh venenatis sed. Proin id dapibus turpis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nam in est tortor. Nunc mattis nunc velit, a malesuada magna imperdiet vitae. Aliquam erat volutpat. Morbi bibendum, tortor eget gravida rhoncus, magna nisl viverra velit, eget tempus ante est in risus. Morbi nec enim velit.</Paragraph>
+        <Image src="https://placeimg.com/400/250/nature/sepia" caption="Example caption 2" alt="Example image 2" size="large" />
+        <Paragraph>Vestibulum gravida sapien urna, eget blandit tellus sodales non. Nunc dolor ipsum, tincidunt at nisl in, luctus rutrum sem. Donec semper luctus turpis, vitae euismod erat tincidunt quis. Duis vitae cursus nisi. Duis molestie mollis urna a posuere. Mauris suscipit lacus in ultricies dignissim. Nam venenatis aliquet ante ac molestie. Vestibulum quis tortor est. Proin varius porta nulla. Cras id libero quis purus tincidunt ultrices. Pellentesque et ultricies nulla, ut hendrerit leo. </Paragraph>
+        
       </Box>
     </Box>
   );

--- a/src/styles/components/program-navi.styl
+++ b/src/styles/components/program-navi.styl
@@ -1,0 +1,25 @@
+.program-navi
+  background: TEAL_DARK
+  color: BACKGROUND
+  
+  .link
+    background: BACKGROUND
+    color: TEAL_DARK
+    display: inline-block
+    margin: 0 0.5em
+    padding: 0.25em 0.5em
+    
+    &:hover
+      color: TEAL_LIGHT
+      text-decoration: none
+
+    &.big
+      font-weight: bold
+      
+      &::after
+        content: '>'
+        margin: 0 0.5em
+
+  .grommetux-anchor__icon
+    height: auto
+    padding: 0

--- a/src/styles/components/wildcam-info-page.styl
+++ b/src/styles/components/wildcam-info-page.styl
@@ -1,2 +1,2 @@
 .wildcam-info-page
-  background: grey
+  background: BACKGROUND

--- a/src/styles/components/wildcam-info-page.styl
+++ b/src/styles/components/wildcam-info-page.styl
@@ -1,0 +1,2 @@
+.wildcam-info-page
+  background: grey


### PR DESCRIPTION
## PR Overview
This PR adds a number of content-focused features to the WildCam _Darien_ Lab _Program._
- The Darien Home page has been modified to add Darien-specific content (e.g. a Darien navi and a link to a Darien Talk board.)
- New Info/Content pages (e.g. "Ecology") are being added - these serve as informative teaching guides for Teachers and Students to refer to. (These pages should have near zero mechanical functionality.)
- On the subject of a Darien navi, a new way of navigating the Darien Program is currently being considered. WARNING: at the moment, this new way _does_ cause some visual UI clashing with the overall navigation for Zooniverse Classroom; we're still rethinking the UI design here.

This PR's updates will _only_ affect Darien components, and should not affect any Astro or general Zooniverse Classroom functionality. I'm making these updates fast and simple in response to HHMI's feedback based on the 2018 Rebuild Part 4. (PR #125)

### Status
WIP. The only thing left for this PR is to give the Ecology page some placeholder content, and maybe to add some more (placeholder) info pages.