### PR TITLE
Manage our own oauth redirects. Add a initialization loading page.

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import App from 'grommet/components/App';
 import Box from 'grommet/components/Box';
@@ -11,6 +12,7 @@ import AuthContainer from '../containers/layout/AuthContainer';
 import AppNotification from '../containers/layout/AppNotification';
 import ProgramHomeContainer from '../containers/common/ProgramHomeContainer';
 import JoinPageContainer from '../containers/common/JoinPageContainer';
+import GenericStatusPage from './common/GenericStatusPage';
 
 import AppHeader from './layout/AppHeader';
 import {
@@ -20,11 +22,16 @@ import {
   getRedirectSearch
 } from '../lib/redirect-manager';
 
-const Main = ({ admin, location }) => {
+const Main = ({ admin, initialised, location }) => {
   const redirect = isRedirectStored();
   const pathname = getRedirectPathname();
   const search = getRedirectSearch();
-  if (redirect && location.pathname !== pathname) {
+  if (!initialised) {
+    Actions.checkLoginUser();
+    return (<GenericStatusPage status="fetching" message="Loading" />)
+  }
+
+  if (redirect && location.pathname !== pathname && initialised) {
     removeLocation();
 
     if (search) {
@@ -54,16 +61,19 @@ const Main = ({ admin, location }) => {
 };
 
 Main.defaultProps = {
-  admin: false
+  admin: false,
+  initialised: false
 };
 
 Main.propTypes = {
-  admin: PropTypes.bool
+  admin: PropTypes.bool,
+  initialised: PropTypes.bool
 };
 
 function mapStateToProps(state) {
   return {
-    admin: state.auth.admin
+    admin: state.auth.admin,
+    initialised: state.auth.initialised
   };
 }
 

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -65,7 +65,6 @@ function AstroClassroomsTable(props) {
           const joinURL = `${config.origin}/#/${props.selectedProgram.slug}/students/classrooms/${classroom.id}/join?token=${classroom.joinToken}`;
           // Can we get linked assignments with classrooms in single get request?
           // No, if we want this, then we need to open an issue with the API
-          // TODO replace classifications_target with calculated percentage
 
           // The trailing slash is inconsistent in React Router 4's match.url property...
           const editURL = (props.match.url[props.match.url.length - 1] === '/') ? props.match.url : `${props.match.url}/`;

--- a/src/containers/layout/AuthContainer.jsx
+++ b/src/containers/layout/AuthContainer.jsx
@@ -10,11 +10,7 @@ import { storeLocation, redirectErrorHandler } from '../../lib/redirect-manager'
 
 export class AuthContainer extends React.Component {
   constructor(props) {
-    super(props);
-
-    if (!props.initialised) {
-      Actions.checkLoginUser();
-    }
+    super();
 
     this.login = this.login.bind(this);
   }
@@ -26,7 +22,7 @@ export class AuthContainer extends React.Component {
   login() {
     new Promise((resolve, reject) => {
       const location = this.props.location;
-      if (location.pathname !== '/') resolve(storeLocation(location.pathname, location.search));
+      resolve(storeLocation(location.pathname, location.search));
     }).then(
       Actions.loginToPanoptes()
     ).catch((error) => { redirectErrorHandler(error); });

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,7 +15,7 @@ import './styles/main.styl';
 
 const store = configureStore();
 
-oauth.init(config.panoptesAppId)
+oauth.init(config.panoptesAppId, { customRedirects: true })
   .then(() => {
     ReactDOM.render((
       <Provider store={store}>


### PR DESCRIPTION
Fixes #121. This is built on zooniverse/panoptes-javascript-client#97 (up to you if you want to install from github or use `npm link` to test).

I refactored the oauth initialization to include `customRedirects: true` because this app is managing the redirects on its own. I updated the redirect code in the `AuthContainer` to store the redirect in localStorage regardless of what page you're on. I also moved the initial login check to `Main` and added a general status loading page before we know if there's a user or not which just seems like good general practice. 