### PR TITLE
Make sure the program is returned. Only do join request in cdm

### DIFF
--- a/src/containers/common/JoinPageContainer.jsx
+++ b/src/containers/common/JoinPageContainer.jsx
@@ -25,34 +25,29 @@ export class JoinPageContainer extends React.Component {
     // I2A doesn't have a student interface here.
     Actions.getPrograms().then((programs) => {
       Actions.getProgram({ programs, param: this.props.match.params.program })
-      .then(() => {
-        if (this.props.initialised && this.props.user) {
-          this.joinClassroom(this.props);
+      .then((program) => {
+        if (program &&
+          this.props.initialised &&
+          this.props.user &&
+          this.props.classroomsStatus === CLASSROOMS_STATUS.IDLE
+        ) {
+          this.joinClassroom(this.props, program);
         }
       });
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.selectedProgram &&
-        nextProps.classroomsStatus === CLASSROOMS_STATUS.IDLE &&
-        nextProps.initialised &&
-        nextProps.user) {
-      // TODO debug when you are attempt to join your own classroom. Getting 500 error?
-      this.joinClassroom(nextProps);
-    }
-  }
-
-  joinClassroom(props) {
+  joinClassroom(props, program) {
     const classroomId = props.match.params.classroomId;
     const joinToken = queryString.parse(props.location.search);
+    const selectedProgram = program || props.selectedProgram;
 
     Actions.joinClassroom({ classroomId, joinToken: joinToken.token })
       .then(() => {
         if ((props.programsStatus === PROGRAMS_STATUS.SUCCESS && props.classroomsStatus === CLASSROOMS_STATUS.SUCCESS) &&
-            (props.selectedProgram && props.selectedProgram.metadata && props.selectedProgram.metadata.redirectOnJoin)) {
+            (selectedProgram && selectedProgram.metadata && selectedProgram.metadata.redirectOnJoin)) {
           // Make sure they see the success message before redirecting
-          setTimeout(props.history.replace(`/${props.selectedProgram.slug}/students`), 2000);
+          setTimeout(props.history.replace(`/${selectedProgram.slug}/students`), 2000);
         }
       });
   }

--- a/src/ducks/programs.js
+++ b/src/ducks/programs.js
@@ -249,8 +249,6 @@ Effect('getProgram', (data) => {
       Actions.programs.setStatus(PROGRAMS_STATUS.SUCCESS);
       Actions.programs.selectProgram(program);
       return program;
-    }).then((program) => {
-      // Actions.getClassroomsAndAssignments(program.id);
     }).catch(error => handleError(error));
 });
 


### PR DESCRIPTION
This fixes #89. 

This refactors the `JoinPageContainer` to only rely on `componentDidMount` to call the join classroom request. Since #129, with the refactor to have a loading splash screen before we know whether or not there is a user, we can be assured that by the time this is called, we won't need `componentWillReceiveProps` to cover that case of waiting for the response of the user authorization. 

Secondly, I fixed the `getProgram` action to make sure it returns the program and pass that in as an argument into `joinClassroom` rather than again wait for the `nextProps.selectedProgram` in `componentWillReceiveProps`

Removing the call for `joinClassroom` out of `componentWillReceiveProps` removes the condition where it could be called twice causing #89. It also is good for upcoming React 17 since this lifecycle method will be deprecated. 

This can be tested by joining a user to a classroom for the first time using the classroom join link. @shaunanoordin could you test the wildcam labs version of classroom joining to make sure the redirect to the student pages works? Thanks!