### PR TITLE
WildCam Lab Classrooms - 2018 Rebuild - part 8

### DIFF
--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -374,8 +374,6 @@ class AssignmentForm extends React.Component {
     const props = this.props;
     const state = this.state;
     
-    console.log('+++XXX RENDER!!! ', state);
-
     //Get students and assignments only for this classroom.
     //const students = (props.selectedClassroom && props.selectedClassroom.students) ? props.selectedClassroom.students : [];
     //const assignments = (props.selectedClassroom && props.assignments && props.assignments[props.selectedClassroom.id])
@@ -512,8 +510,6 @@ class AssignmentForm extends React.Component {
           </fieldset>
         )}
         
-        <p>--Students: {state.students.length}--</p>
-        
         <StudentsList
           selectedClassroom={props.selectedClassroom}
           selectedAssignment={props.selectedAssignment}
@@ -526,7 +522,6 @@ class AssignmentForm extends React.Component {
             } else {
               updatedStudents.push(studentId);
             }
-            
             this.setState({
               students: updatedStudents
             });

--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -334,7 +334,7 @@ class AssignmentForm extends React.Component {
         ? state.subjects.map(sub => sub.subject_id)
         : [];
       
-      return Actions.wcc_editAssignment({
+      return Actions.wcc_teachers_editAssignment({
         selectedAssignment: props.selectedAssignment,
         assignmentData: state.form,
         filters,
@@ -508,6 +508,34 @@ class AssignmentForm extends React.Component {
             //TODO
             alert('ALPHA: This feature is a work in progress.');
             console.log('+++ Updated List of Students: ', updatedListOfStudents);
+            
+            //TODO: this is how zootester4 is removed from a list that includes zootester2 and zootester3
+            /*
+              {
+                "data":{
+                  "attributes":{
+                    "name":"Gorongosa 8-Aug-2018 Lions",
+                    "metadata":{
+                      "classifications_target":"5",
+                      "description":"Lions!",
+                      "duedate":"2024-01-01",
+                      "filters":{
+                        "species":["lioncub","lionfemale","lionmale"]
+                      },
+                      "subjects":["685945","685958","685959","711502","711506"]
+                    }
+                  },
+                  "relationships":{
+                    "student_users":{
+                      "data":[
+                        {"id":"13138","type":"student_user"},
+                        {"id":"13139","type":"student_user"}
+                      ]
+                    }
+                  }
+                }
+              }*/
+
           }}
         />
 
@@ -543,7 +571,7 @@ class AssignmentForm extends React.Component {
                 icon={<CloseIcon size="small" />}
                 label={TEXT.ACTIONS.DELETE}
                 onClick={() => {
-                  return Actions.wcc_deleteAssignment(props.selectedAssignment)
+                  return Actions.wcc_teachers_deleteAssignment(props.selectedAssignment)
                   .then(() => {
                     //Message
                     Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.ASSIGNMENT_DELETED, status: 'ok' });
@@ -555,7 +583,7 @@ class AssignmentForm extends React.Component {
                       props.history && props.history.push('../');
                     });
                   }).catch((err) => {
-                    //Error messaging done in Actions.wcc_deleteAssignment()
+                    //Error messaging done in Actions.wcc_teachers_deleteAssignment()
                   });
                 }}
               />

--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -202,12 +202,10 @@ class AssignmentForm extends React.Component {
             ? selectedAssignment.relationships.student_users.data.map(s => s.id)
             : [];
           
-          console.log('+++ INITIALISE_PART_TWO, STUDENTS: ', newStudents);
-          
           this.setState({
             subjects: newSubjects,
             filters: newFilters,
-            students: newStudents,  //WARNING: THIS DOES NOTHING FOR SOME REASON
+            students: newStudents,
           });
         }
         
@@ -236,7 +234,6 @@ class AssignmentForm extends React.Component {
     if (!selectedAssignment) {
       this.setState({
         form: INITIAL_FORM_DATA,
-        students: [],
       });
     } else {
       const originalForm = INITIAL_FORM_DATA;
@@ -254,7 +251,6 @@ class AssignmentForm extends React.Component {
       
       this.setState({
         form: updatedForm,
-        students: [],  //TODO
       });
     }
     
@@ -269,6 +265,7 @@ class AssignmentForm extends React.Component {
           ...this.state.form,
           ...props.wccwcmSavedAssignmentState,
           classifications_target: props.wccwcmSelectedSubjects.length,
+          //TODO: reload selected students
         }
       });
       Actions.wildcamMap.resetWccWcmAssignmentData();
@@ -376,6 +373,8 @@ class AssignmentForm extends React.Component {
   render() {
     const props = this.props;
     const state = this.state;
+    
+    console.log('+++XXX RENDER!!! ', state);
 
     //Get students and assignments only for this classroom.
     //const students = (props.selectedClassroom && props.selectedClassroom.students) ? props.selectedClassroom.students : [];
@@ -437,8 +436,6 @@ class AssignmentForm extends React.Component {
   render_editState() {
     const props = this.props;
     const state = this.state;
-    
-    console.log('+++ RENDER_EDITSTATE\'S STATE.STUDENTS: ', state.students, state);
     
     return (
       <Form

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -17,13 +17,10 @@ import ScrollToTopOnMount from '../../../containers/common/ScrollToTopOnMount';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
-import Label from 'grommet/components/Label';
 import Heading from 'grommet/components/Heading';
 import Table from 'grommet/components/Table';
 import TableRow from 'grommet/components/TableRow';
 
-import AddIcon from 'grommet/components/icons/base/Add';
-import EditIcon from 'grommet/components/icons/base/Edit';
 import LinkNextIcon from 'grommet/components/icons/base/LinkNext';
 
 import {
@@ -35,9 +32,12 @@ import {
 } from '../ducks/index.js';
   
 const TEXT = {
-  WORKING: 'Working...',
-  VIEW: 'View',
-  CREATE_NEW_CLASSROOM: 'Create new classroom',
+  TITLE: {
+    YOUR_ASSIGNMENTS: 'Your Assignments'
+  },
+  ACTIONS: {
+    START_ASSIGNMENT: 'Start assignment'
+  }
 };
 
 class AssignmentsListForStudents extends React.Component {
@@ -60,7 +60,7 @@ class AssignmentsListForStudents extends React.Component {
         margin="medium"
         pad="medium"
       >
-        <Heading tag="h2">Your Assignments</Heading>
+        <Heading tag="h2">{TEXT.TITLE.YOUR_ASSIGNMENTS}</Heading>
         {(() => {
           if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS && props.assignmentsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
             return this.render_readyState();
@@ -109,7 +109,23 @@ class AssignmentsListForStudents extends React.Component {
                 <Heading tag='h4'>{ass.name}</Heading>
               </td>
               <td>
-                <Button>=></Button>
+                <Box
+                    className="actions-panel"
+                    direction="row"
+                    justify="end"
+                  >
+                    <Button
+                      className="button"
+                      icon={<LinkNextIcon size="small" />}
+                      label={TEXT.ACTIONS.START_ASSIGNMENT}
+                      
+                      disabled={true}
+                      onClick={() => {
+                        //TODO
+                        console.error('//TODO');
+                      }}
+                    />
+                  </Box>
               </td>
             </TableRow>
           ))}

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -1,0 +1,161 @@
+/*
+AssignmentsListForStudents
+--------------------------
+
+Component for listing all assignments. (This is for the student's view.)
+
+--------------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
+
+import StatusWorking from './StatusWorking';
+import ScrollToTopOnMount from '../../../containers/common/ScrollToTopOnMount';
+
+import Box from 'grommet/components/Box';
+import Button from 'grommet/components/Button';
+import Label from 'grommet/components/Label';
+import Heading from 'grommet/components/Heading';
+import Table from 'grommet/components/Table';
+import TableRow from 'grommet/components/TableRow';
+
+import AddIcon from 'grommet/components/icons/base/Add';
+import EditIcon from 'grommet/components/icons/base/Edit';
+import LinkNextIcon from 'grommet/components/icons/base/LinkNext';
+
+import {
+  WILDCAMCLASSROOMS_COMPONENT_MODES as MODES,
+  WILDCAMCLASSROOMS_DATA_STATUS,
+  WILDCAMCLASSROOMS_INITIAL_STATE,
+  WILDCAMCLASSROOMS_PROPTYPES,
+  WILDCAMCLASSROOMS_MAP_STATE,
+} from '../ducks/index.js';
+  
+const TEXT = {
+  WORKING: 'Working...',
+  VIEW: 'View',
+  CREATE_NEW_CLASSROOM: 'Create new classroom',
+};
+
+class AssignmentsListForStudents extends React.Component {
+  constructor() {
+    super();
+    
+    //Initialise:
+    //Set data to match view state
+    Actions.wildcamClassrooms.resetSelectedClassroom();
+    //TODO: Reset selectedAssignment
+  }
+  
+  // ----------------------------------------------------------------
+  
+  render() {
+    const props = this.props;
+    
+    //Sanity check
+    if (!props.classroomsList) return null;
+    
+    return (
+      <Box
+        className="classrooms-list"
+        margin="medium"
+        pad="medium"
+      >
+        <Heading tag="h2">List of Classrooms</Heading>
+        {(() => {
+          if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
+            return this.render_readyState();
+          } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.FETCHING || props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
+            return this.render_workingState();
+          }
+        })()}
+        
+        <ScrollToTopOnMount />
+      </Box>
+    );
+  }
+  
+  render_readyState() {
+    const props = this.props;
+    
+    return (
+      <Box>
+        <Table className="table">
+          <tbody>
+          {props.classroomsList.map((classroom, index) => {
+            return (
+              <TableRow
+                className="item"
+                key={`classrooms-list_${index}`}
+              >
+                <td>
+                  <Heading tag="h3">{classroom.name}</Heading>
+                </td>
+                <td>
+                  <Box
+                    className="actions-panel"
+                    direction="row"
+                    justify="end"
+                  >
+                    <Button
+                      className="button"
+                      icon={<LinkNextIcon size="small" />}
+                      label={TEXT.VIEW}
+                      onClick={() => {
+                        //Transition to: View One Classroom
+                        props.history && props.history.push(`${props.match.url.replace(/\/+$/,'')}/classrooms/${classroom.id}`);
+                      }}
+                    />
+                  </Box>
+                </td>
+              </TableRow>
+            );
+          })}
+          </tbody>
+        </Table>
+        
+        <Box
+          className="actions-panel"
+          direction="row"
+          justify="end"
+          pad="medium"
+        >
+          <Button
+            className="button"
+            icon={<AddIcon size="small" />}
+            label={TEXT.CREATE_NEW_CLASSROOM}
+            onClick={() => {
+              //Transition to: Create New Classroom
+              props.history && props.history.push(`${props.match.url.replace(/\/+$/,'')}/classrooms/new`);
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
+  
+  render_workingState() {
+    return (
+      <StatusWorking />
+    );
+  }
+};
+
+AssignmentsListForStudents.defaultProps = {
+  ...WILDCAMCLASSROOMS_INITIAL_STATE,
+};
+
+AssignmentsListForStudents.propTypes = {
+  ...WILDCAMCLASSROOMS_PROPTYPES,
+};
+
+function mapStateToProps(state) {
+  return {
+    ...WILDCAMCLASSROOMS_MAP_STATE(state),
+  };
+}
+
+export default connect(mapStateToProps)(AssignmentsListForStudents);

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -43,11 +43,10 @@ const TEXT = {
 class AssignmentsListForStudents extends React.Component {
   constructor() {
     super();
-    
-    //Initialise:
-    //Set data to match view state
-    Actions.wildcamClassrooms.resetSelectedClassroom();
-    //TODO: Reset selectedAssignment
+  }
+  
+  componentDidMount() {
+    Actions.wcc_fetchAssignments({});
   }
   
   // ----------------------------------------------------------------
@@ -55,30 +54,30 @@ class AssignmentsListForStudents extends React.Component {
   render() {
     const props = this.props;
     
-    //Sanity check
-    if (!props.classroomsList) return null;
-    
     return (
       <Box
-        className="classrooms-list"
+        className="assignments-list-for-students"
         margin="medium"
         pad="medium"
       >
-        <Heading tag="h2">List of Classrooms</Heading>
-        {(() => {
+        <Heading tag="h2">Your Assignments</Heading>
+        {/*(() => {
           if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
             return this.render_readyState();
           } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.FETCHING || props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
             return this.render_workingState();
           }
-        })()}
+        })()*/}
+        
+        <p>Classrooms Status: {props.classroomsStatus}</p>
+        <p>Assignments Status: {props.assignmentsStatus}</p>
         
         <ScrollToTopOnMount />
       </Box>
     );
   }
   
-  render_readyState() {
+  /*render_readyState() {
     const props = this.props;
     
     return (
@@ -116,23 +115,6 @@ class AssignmentsListForStudents extends React.Component {
           })}
           </tbody>
         </Table>
-        
-        <Box
-          className="actions-panel"
-          direction="row"
-          justify="end"
-          pad="medium"
-        >
-          <Button
-            className="button"
-            icon={<AddIcon size="small" />}
-            label={TEXT.CREATE_NEW_CLASSROOM}
-            onClick={() => {
-              //Transition to: Create New Classroom
-              props.history && props.history.push(`${props.match.url.replace(/\/+$/,'')}/classrooms/new`);
-            }}
-          />
-        </Box>
       </Box>
     );
   }
@@ -141,7 +123,7 @@ class AssignmentsListForStudents extends React.Component {
     return (
       <StatusWorking />
     );
-  }
+  }*/
 };
 
 AssignmentsListForStudents.defaultProps = {

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -61,13 +61,18 @@ class AssignmentsListForStudents extends React.Component {
         pad="medium"
       >
         <Heading tag="h2">Your Assignments</Heading>
-        {/*(() => {
-          if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
+        {(() => {
+          if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS && props.assignmentsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS) {
             return this.render_readyState();
-          } else if (props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.FETCHING || props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING) {
+          } else if (
+            props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.FETCHING
+            || props.classroomsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING
+            || props.assignmentsStatus === WILDCAMCLASSROOMS_DATA_STATUS.FETCHING
+            || props.assignmentsStatus === WILDCAMCLASSROOMS_DATA_STATUS.SENDING
+          ) {
             return this.render_workingState();
           }
-        })()*/}
+        })()}
         
         <p>Classrooms Status: {props.classroomsStatus}</p>
         <p>Assignments Status: {props.assignmentsStatus}</p>
@@ -77,44 +82,15 @@ class AssignmentsListForStudents extends React.Component {
     );
   }
   
-  /*render_readyState() {
+  render_readyState() {
     const props = this.props;
+    
+    console.log('+++ CLASSROOMS: \n', props.classroomsList);
+    console.log('+++ ASSIGNMENTS: \n', props.assignmentsList);
     
     return (
       <Box>
-        <Table className="table">
-          <tbody>
-          {props.classroomsList.map((classroom, index) => {
-            return (
-              <TableRow
-                className="item"
-                key={`classrooms-list_${index}`}
-              >
-                <td>
-                  <Heading tag="h3">{classroom.name}</Heading>
-                </td>
-                <td>
-                  <Box
-                    className="actions-panel"
-                    direction="row"
-                    justify="end"
-                  >
-                    <Button
-                      className="button"
-                      icon={<LinkNextIcon size="small" />}
-                      label={TEXT.VIEW}
-                      onClick={() => {
-                        //Transition to: View One Classroom
-                        props.history && props.history.push(`${props.match.url.replace(/\/+$/,'')}/classrooms/${classroom.id}`);
-                      }}
-                    />
-                  </Box>
-                </td>
-              </TableRow>
-            );
-          })}
-          </tbody>
-        </Table>
+        ...
       </Box>
     );
   }
@@ -123,7 +99,7 @@ class AssignmentsListForStudents extends React.Component {
     return (
       <StatusWorking />
     );
-  }*/
+  }
 };
 
 AssignmentsListForStudents.defaultProps = {

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -73,10 +73,6 @@ class AssignmentsListForStudents extends React.Component {
             return this.render_workingState();
           }
         })()}
-        
-        <p>Classrooms Status: {props.classroomsStatus}</p>
-        <p>Assignments Status: {props.assignmentsStatus}</p>
-        
         <ScrollToTopOnMount />
       </Box>
     );
@@ -85,13 +81,41 @@ class AssignmentsListForStudents extends React.Component {
   render_readyState() {
     const props = this.props;
     
-    console.log('+++ CLASSROOMS: \n', props.classroomsList);
-    console.log('+++ ASSIGNMENTS: \n', props.assignmentsList);
+    //Sanity check
+    if (!props.classroomsList || !props.assignmentsList) return null;
     
     return (
-      <Box>
-        ...
-      </Box>
+      <Table>
+        {props.classroomsList.map(classroom => this.render_readyState_classroom(classroom))}
+      </Table>
+    );
+  }
+  
+  render_readyState_classroom(classroom) {
+    const props = this.props;
+    
+    //Sanity check not required.
+    
+    const assignmentsForThisClassroom = props.assignmentsList.filter(ass => parseInt(ass.classroomId) === parseInt(classroom.id));
+    
+    return (
+      <TableRow key={`student_classroom_${classroom.id}`}>
+        <td>
+          <Heading tag='h3'>{classroom.name}</Heading>
+          <Table>
+          {assignmentsForThisClassroom.map(ass => (
+            <TableRow key={`student_classroom_${classroom.id}_assignment_${ass.id}`}>
+              <td>
+                <Heading tag='h4'>{ass.name}</Heading>
+              </td>
+              <td>
+                <Button>=></Button>
+              </td>
+            </TableRow>
+          ))}
+          </Table>
+        </td>
+      </TableRow>
     );
   }
   

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -85,6 +85,7 @@ const TEXT = {
     CLASSROOM_CREATED: 'Classroom created',
     CLASSROOM_EDITED: 'Changes saved',
     CLASSROOM_DELETED: 'Classroom deleted',
+    STUDENT_DELETED_FROM_CLASSROOM: 'Student removed from classroom',
   },
 };
 
@@ -105,7 +106,6 @@ class ClassroomForm extends React.Component {
     this.state = {
       view: VIEWS.CREATE_NEW,
       form: INITIAL_FORM_DATA,
-      //TODO: students, an advanced form of data.
     };
   }
   
@@ -392,12 +392,19 @@ class ClassroomForm extends React.Component {
         <StudentsList
           selectedClassroom={props.selectedClassroom}
           selectedAssignment={null}
-          doUpdateStudents={(updatedListOfStudents) => {
-            //TODO
-            alert('ALPHA: This feature is a work in progress.');
-            console.log('+++ Updated List of Students: ', updatedListOfStudents);
+          doDeleteStudent={(student) => {
+            const studentId = student && student.id;
             
-            //NOTE: to delete individual students: `DELETE https://education-api-staging.zooniverse.org/teachers/classrooms/439/student_users/420`
+            return Actions.wcc_teachers_deleteStudentFromClassroom({ studentId, selectedClassroom: props.selectedClassroom })
+            .then(() => {
+              //Message
+              Actions.wildcamClassrooms.setToast({ message: TEXT.SUCCESS.STUDENT_DELETED_FROM_CLASSROOM, status: 'ok' });
+
+              //Refresh
+              return Actions.wcc_teachers_refreshData({ selectedProgram: props.selectedProgram, selectedClassroom: props.selectedClassroom });
+            }).catch((err) => {
+              //Error messaging done in Actions.wcc_teachers_deleteStudentFromClassroom()
+            });
           }}
         />
       </Box>

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -396,6 +396,8 @@ class ClassroomForm extends React.Component {
             //TODO
             alert('ALPHA: This feature is a work in progress.');
             console.log('+++ Updated List of Students: ', updatedListOfStudents);
+            
+            //NOTE: to delete individual students: `DELETE https://education-api-staging.zooniverse.org/teachers/classrooms/439/student_users/420`
           }}
         />
       </Box>

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -17,7 +17,6 @@ import ScrollToTopOnMount from '../../../containers/common/ScrollToTopOnMount';
 
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
-import Label from 'grommet/components/Label';
 import Heading from 'grommet/components/Heading';
 import Table from 'grommet/components/Table';
 import TableRow from 'grommet/components/TableRow';

--- a/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomsList.jsx
@@ -43,7 +43,9 @@ const TEXT = {
 class ClassroomsList extends React.Component {
   constructor() {
     super();
-    
+  }
+  
+  componentDidMount() {
     //Initialise:
     //Set data to match view state
     Actions.wildcamClassrooms.resetSelectedClassroom();
@@ -54,9 +56,6 @@ class ClassroomsList extends React.Component {
   
   render() {
     const props = this.props;
-    
-    //Sanity check
-    if (!props.classroomsList) return null;
     
     return (
       <Box
@@ -80,6 +79,9 @@ class ClassroomsList extends React.Component {
   
   render_readyState() {
     const props = this.props;
+    
+    //Sanity check
+    if (!props.classroomsList) return null;
     
     return (
       <Box>

--- a/src/modules/wildcam-classrooms/components/StudentsList.jsx
+++ b/src/modules/wildcam-classrooms/components/StudentsList.jsx
@@ -95,9 +95,7 @@ class StudentsList extends React.Component {
     //Are we viewing the student list of a Classroom or an Assignment?
     let listType = '';
     if (props.doDeleteStudent) listType = 'classroom';
-    if (props.doSelectStudent && props.selectedAssignment) listType = 'assignment';
-    console.log('+++ SELECTED CLASSROOM: ', props.selectedClassroom);
-    console.log('+++ SELECTED STUDENTS: ', props.selectedStudents);
+    if (props.doSelectStudent) listType = 'assignment';
     
     return (
       <Box

--- a/src/modules/wildcam-classrooms/components/StudentsList.jsx
+++ b/src/modules/wildcam-classrooms/components/StudentsList.jsx
@@ -11,15 +11,27 @@ Props:
     students for.
 - selectedAssignment: (optional) the WildCam Assignment that we're listing
     students for.
-- doUpdateStudents: (optional) function that's called when the user updates the
-    list of selected students.
+- selectedStudents: (optional) the list of students currently selected for this
+    Assignment. Only used when viewing students in Assignments.
+- doDeleteStudent: (optional) function that's called when the user deletes one
+    student. (When viewing students for Classrooms only.)
+- doSelectStudent: (optional) function that's called when the user selects OR
+    unselects a student from the list of selected students. (When viewing
+    students for Assignments only.)
 
 Usage:
   <StudentsList
     selectedClassroom={myClassroom}
-    selectedAssignment={null}
-    doUpdateStudents={(arrayOfSelectedStudents) => {
-      console.log('The user has chosen the following students: ', arrayOfSelectedStudents);
+    doDeleteStudent={(student) => {
+      ...
+    }}
+  />
+  ...or...
+  <StudentsList
+    selectedClassroom={myClassroom}
+    selectedAssignment={myAssignment}
+    doSelectStudent={(student) => {
+      ...
     }}
   />
 
@@ -70,60 +82,22 @@ const TEXT = {
 class StudentsList extends React.Component {
   constructor() {
     super();
-    this.state = {
-      students: [],
-      form: {},
-    };
   }
   
   // ----------------------------------------------------------------
   
-  componentDidMount() {
-    this.initialise(this.props);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.initialise(nextProps);
-  }
-  
-  /*  //Initialise: populate the form with students
-   */
-  initialise(props = this.props) {
-    //Sanity check
-    if (!props.selectedClassroom) return;
-    
-    //Get all the students attached to this classroom
-    const form = {};
-    const students = props.selectedClassroom.students || [];
-    students.map((stud) => { form[stud.id] = true; });
-          
-    //If there's a selected Assignment, make sure only students in the
-    //assignment are selected.
-    if (props.selectedAssignment) {
-      //TODO
-    }
-    
-    this.setState({ students, form });
-  }
-  
-  // ----------------------------------------------------------------
-  
-  updateForm(e) {
-    this.setState({
-      form: {
-        ...this.state.form,
-        [e.target.id]: e.target.value
-      }
-    });
-  }
-
-  // ----------------------------------------------------------------
-
   render() {
     const props = this.props;
-    const state = this.state;
     
-    const userCanUpdateList = props.doUpdateStudents !== null;
+    //Sanity check
+    if (!props.selectedClassroom) return null;
+    
+    //Are we viewing the student list of a Classroom or an Assignment?
+    let listType = '';
+    if (props.doDeleteStudent) listType = 'classroom';
+    if (props.doSelectStudent && props.selectedAssignment) listType = 'assignment';
+    console.log('+++ SELECTED CLASSROOM: ', props.selectedClassroom);
+    console.log('+++ SELECTED STUDENTS: ', props.selectedStudents);
     
     return (
       <Box
@@ -134,7 +108,7 @@ class StudentsList extends React.Component {
         <Heading tag="h3">{TEXT.HEADINGS.STUDENTS}</Heading>
         <Table className="table">
           <tbody>
-            {state.students.map((stud) => {
+            {props.selectedClassroom.students.map((stud) => {
               return (
                 <TableRow
                   className="item"
@@ -145,8 +119,25 @@ class StudentsList extends React.Component {
                   </td>
                   <td>
                     ({stud.zooniverseLogin})
+                    
+                    +++{stud.id}+++
                   </td>
-                  {(userCanUpdateList) && (
+                  {(listType === 'classroom') && (
+                    <td>
+                      <Box
+                        className="actions-panel"
+                        direction="row"
+                        justify="end"
+                      >
+                        <Button
+                          onClick={(e) => {
+                            props.doDeleteStudent(stud);
+                          }}
+                        >X</Button>
+                      </Box>
+                    </td>
+                  )}
+                  {(listType === 'assignment') && (
                     <td>
                       <Box
                         className="actions-panel"
@@ -154,14 +145,9 @@ class StudentsList extends React.Component {
                         justify="end"
                       >
                         <CheckBox
-                          checked={state.form[stud.id]}
+                          checked={props.selectedStudents && !!props.selectedStudents.find((s) => s === stud.id)}
                           onChange={(e) => {
-                            this.setState({
-                              form: {
-                                ...state.form,
-                                [stud.id]: !state.form[stud.id],
-                              }
-                            });
+                            props.doSelectStudent(stud.id);
                           }}
                         />
                       </Box>
@@ -172,19 +158,6 @@ class StudentsList extends React.Component {
             })}
           </tbody>
         </Table>
-        {(userCanUpdateList) &&
-          <Footer>
-            <Button
-              className="button"
-              label={TEXT.ACTIONS.UPDATE_STUDENTS}
-              onClick={() => {
-                let updatedListOfStudents = [];
-                //TODO
-                props.doUpdateStudents(this.state.form);
-              }}
-            />
-          </Footer>
-        }
       </Box>
     );
   }
@@ -196,12 +169,14 @@ class StudentsList extends React.Component {
 
 StudentsList.defaultProps = {
   ...WILDCAMCLASSROOMS_INITIAL_STATE,
-  doUpdateStudents: null,
+  selectedStudents: [],
+  doSelectStudent: null,
 };
 
 StudentsList.propTypes = {
   ...WILDCAMCLASSROOMS_PROPTYPES,
-  doUpdateStudents: PropTypes.func,
+  selectedStudents: PropTypes.array,
+  doSelectStudent: PropTypes.func,
 };
 
 export default StudentsList;

--- a/src/modules/wildcam-classrooms/components/StudentsList.jsx
+++ b/src/modules/wildcam-classrooms/components/StudentsList.jsx
@@ -48,11 +48,12 @@ import PropTypes from 'prop-types';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import CheckBox from 'grommet/components/CheckBox';
-import Footer from 'grommet/components/Footer';
 import Form from 'grommet/components/Form';
 import Heading from 'grommet/components/Heading';
 import Table from 'grommet/components/Table';
 import TableRow from 'grommet/components/TableRow';
+
+import CloseIcon from 'grommet/components/icons/base/Close';
 
 import {
   WILDCAMCLASSROOMS_COMPONENT_MODES as MODES,
@@ -117,8 +118,6 @@ class StudentsList extends React.Component {
                   </td>
                   <td>
                     ({stud.zooniverseLogin})
-                    
-                    +++{stud.id}+++
                   </td>
                   {(listType === 'classroom') && (
                     <td>
@@ -131,7 +130,9 @@ class StudentsList extends React.Component {
                           onClick={(e) => {
                             props.doDeleteStudent(stud);
                           }}
-                        >X</Button>
+                        >
+                          <CloseIcon size="small" />
+                        </Button>
                       </Box>
                     </td>
                   )}

--- a/src/modules/wildcam-classrooms/containers/WildCamForEducators.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamForEducators.jsx
@@ -1,9 +1,9 @@
 /*
-WildCam Students
-----------------
+WildCam Classrooms
+------------------
 
-The primary component for Teachers, allowing them to view their assigned
-Assignments.
+The primary component for Teachers, allowing them to view and manage classrooms
+and assignments for WildCam-type programs/projects.
 
 --------------------------------------------------------------------------------
  */
@@ -35,7 +35,7 @@ import {
 --------------------------------------------------------------------------------
  */
 
-class WildCamStudents extends React.Component {
+class WildCamForEducators extends React.Component {
   constructor() {
     super();
   }
@@ -116,7 +116,7 @@ class WildCamStudents extends React.Component {
 --------------------------------------------------------------------------------
  */
 
-WildCamStudents.defaultProps = {
+WildCamForEducators.defaultProps = {
   history: null,
   location: null,
   match: null,
@@ -126,7 +126,7 @@ WildCamStudents.defaultProps = {
   ...WILDCAMCLASSROOMS_INITIAL_STATE,
 };
 
-WildCamStudents.propTypes = {
+WildCamForEducators.propTypes = {
   history: PropTypes.object,
   location: PropTypes.object,
   match: PropTypes.object,
@@ -142,4 +142,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(WildCamStudents);
+export default connect(mapStateToProps)(WildCamForEducators);

--- a/src/modules/wildcam-classrooms/containers/WildCamForStudents.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamForStudents.jsx
@@ -53,7 +53,7 @@ class WildCamForStudents extends React.Component {
     //Sanity check
     if (!props.selectedProgram) return;
     
-    return Actions.wcc_teachers_fetchClassrooms({ selectedProgram: props.selectedProgram })
+    return Actions.wcc_students_fetchClassrooms({ selectedProgram: props.selectedProgram })
     .then(() => {
       //Nothing
     });

--- a/src/modules/wildcam-classrooms/containers/WildCamForStudents.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamForStudents.jsx
@@ -1,9 +1,9 @@
 /*
-WildCam Classrooms
-------------------
+WildCam Students
+----------------
 
-The primary component for Teachers, allowing them to view and manage classrooms
-and assignments for WildCam-type programs/projects.
+The primary component for Teachers, allowing them to view their assigned
+Assignments.
 
 --------------------------------------------------------------------------------
  */
@@ -17,10 +17,7 @@ import { Switch, Route } from 'react-router-dom';
 import Box from 'grommet/components/Box';
 import Toast from 'grommet/components/Toast';
 
-import ClassroomsList from '../components/ClassroomsList';
-import ClassroomForm from '../components/ClassroomForm';
-import AssignmentForm from '../components/AssignmentForm';
-import Status404 from '../../../components/common/Status404';
+import AssignmentsListForStudents from '../components/AssignmentsListForStudents';
 
 import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
@@ -35,7 +32,7 @@ import {
 --------------------------------------------------------------------------------
  */
 
-class WildCamClassroom extends React.Component {
+class WildCamForStudents extends React.Component {
   constructor() {
     super();
   }
@@ -83,29 +80,7 @@ class WildCamClassroom extends React.Component {
           </Toast>
         )}
         
-        <Switch>
-          <Route
-            path={`${match.url}/classrooms/:classroom_id/assignments/new`} exact
-            component={AssignmentForm}
-          />
-          <Route
-            path={`${match.url}/classrooms/:classroom_id/assignments/:assignment_id`} exact
-            component={AssignmentForm}
-          />
-          <Route
-            path={`${match.url}/classrooms/new`} exact
-            component={ClassroomForm}
-          />
-          <Route
-            path={`${match.url}/classrooms/:classroom_id`} exact
-            component={ClassroomForm}
-          />
-          <Route
-            path={`${match.url}`} exact
-            component={ClassroomsList}
-          />
-          <Route path="*" component={Status404} />
-        </Switch>
+        <AssignmentsListForStudents />
 
       </Box>
     );
@@ -116,7 +91,7 @@ class WildCamClassroom extends React.Component {
 --------------------------------------------------------------------------------
  */
 
-WildCamClassroom.defaultProps = {
+WildCamForStudents.defaultProps = {
   history: null,
   location: null,
   match: null,
@@ -126,7 +101,7 @@ WildCamClassroom.defaultProps = {
   ...WILDCAMCLASSROOMS_INITIAL_STATE,
 };
 
-WildCamClassroom.propTypes = {
+WildCamForStudents.propTypes = {
   history: PropTypes.object,
   location: PropTypes.object,
   match: PropTypes.object,
@@ -142,4 +117,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(WildCamClassroom);
+export default connect(mapStateToProps)(WildCamForStudents);

--- a/src/modules/wildcam-classrooms/containers/WildCamStudents.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamStudents.jsx
@@ -1,9 +1,9 @@
 /*
-WildCam Classrooms
-------------------
+WildCam Students
+----------------
 
-The primary component for Teachers, allowing them to view and manage classrooms
-and assignments for WildCam-type programs/projects.
+The primary component for Teachers, allowing them to view their assigned
+Assignments.
 
 --------------------------------------------------------------------------------
  */
@@ -35,7 +35,7 @@ import {
 --------------------------------------------------------------------------------
  */
 
-class WildCamClassroom extends React.Component {
+class WildCamStudents extends React.Component {
   constructor() {
     super();
   }
@@ -116,7 +116,7 @@ class WildCamClassroom extends React.Component {
 --------------------------------------------------------------------------------
  */
 
-WildCamClassroom.defaultProps = {
+WildCamStudents.defaultProps = {
   history: null,
   location: null,
   match: null,
@@ -126,7 +126,7 @@ WildCamClassroom.defaultProps = {
   ...WILDCAMCLASSROOMS_INITIAL_STATE,
 };
 
-WildCamClassroom.propTypes = {
+WildCamStudents.propTypes = {
   history: PropTypes.object,
   location: PropTypes.object,
   match: PropTypes.object,
@@ -142,4 +142,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(WildCamClassroom);
+export default connect(mapStateToProps)(WildCamStudents);

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -275,7 +275,6 @@ Effect('wcc_teachers_fetchClassrooms', ({ selectedProgram }) => {
   });
 });
 
-  
 /*  Creates a classroom.
     
     API notes:
@@ -402,6 +401,51 @@ Effect('wcc_teachers_deleteClassroom', (selectedClassroom) => {
     throw(err);
   });
   
+});
+
+/*
+--------------------------------------------------------------------------------
+ */
+
+/*  Fetch all the Classrooms for the selected Program from the Education API.
+    Implicit: the list of Classrooms is limited to what's available to the
+    logged-in user.
+    
+    API notes: 
+      GET /students/classrooms/?program_id=123
+ */
+Effect('wcc_students_fetchClassrooms', ({ selectedProgram }) => {
+  //Sanity check
+  if (!selectedProgram) return;
+  
+  const program_id = selectedProgram.id;
+  
+  Actions.wildcamClassrooms.resetClassrooms();
+  Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.FETCHING);
+  
+  return get('/students/classrooms/', [{ program_id }])
+  
+  .then((response) => {
+    if (!response) { throw 'ERROR (wildcam-classrooms/ducks/wcc_students_fetchClassrooms): No response'; }
+    if (response.ok && response.body) {
+      return response.body;
+    }
+    throw 'ERROR (wildcam-classrooms/ducks/wcc_students_fetchClassrooms): Invalid response';
+  })
+  
+  .then((body) => {
+    Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);
+    Actions.wildcamClassrooms.setClassroomsList(body.data);
+    Actions.wildcamClassrooms.setClassroomsStudents(body.included);
+    return body;
+  })
+  
+  .catch((err) => {
+    Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR);
+    Actions.wildcamClassrooms.setClassroomsStatusDetails(err);
+    showErrorMessage(err);
+    throw(err);
+  });
 });
 
 /*

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -399,8 +399,36 @@ Effect('wcc_teachers_deleteClassroom', (selectedClassroom) => {
     Actions.wildcamClassrooms.setClassroomsStatusDetails(err);
     showErrorMessage(err);
     throw(err);
-  });
+  });  
+});
+
+/*  Deletes a student from a classroom.
+
+    API notes:
+      DELETE /teachers/classrooms/12345/student_users/67890
+ */
+Effect('wcc_teachers_deleteStudentFromClassroom', ({ studentId, selectedClassroom }) => {
+  //Sanity check
+  if (!selectedClassroom) return;
   
+  console.log('+++ DELETE: ', studentId, selectedClassroom);
+  
+  Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);  //WARNING: does this make sense to update Classrooms status?
+  
+  return httpDelete(`/teachers/classrooms/${selectedClassroom.id}/student_users/${studentId}`)
+  .then((response) => {
+    if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_deleteStudentFromClassroom): No response'; }
+    if (response.ok) {
+      return Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);
+    }
+    throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_deleteStudentFromClassroom): Invalid response';
+  })
+  .catch((err) => {
+    Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR);
+    Actions.wildcamClassrooms.setClassroomsStatusDetails(err);
+    showErrorMessage(err);
+    throw(err);
+  });  
 });
 
 /*

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -473,7 +473,9 @@ Effect('wcc_teachers_refreshData', ({ selectedProgram, selectedClassroom = null,
  */
 Effect('wcc_fetchAssignments', ({ selectedClassroom }) => {
   //NOTE: if selectedClassroom isn't specified, this will pull a list of ALL
-  //Assignments belonging to the teacher. This may be useful?
+  //Assignments belonging to the user. This is useful in certain circumstances.
+  //However, do note that the argument needs to be an empty object, e.g.
+  //  `Actions.wcc_fetchAssignments({})`
   
   const classroom_id = (selectedClassroom) ? selectedClassroom.id : undefined;
   

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -411,8 +411,6 @@ Effect('wcc_teachers_deleteStudentFromClassroom', ({ studentId, selectedClassroo
   //Sanity check
   if (!selectedClassroom) return;
   
-  console.log('+++ DELETE: ', studentId, selectedClassroom);
-  
   Actions.wildcamClassrooms.setClassroomsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SENDING);  //WARNING: does this make sense to update Classrooms status?
   
   return httpDelete(`/teachers/classrooms/${selectedClassroom.id}/student_users/${studentId}`)

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -509,8 +509,13 @@ Effect('wcc_teachers_refreshData', ({ selectedProgram, selectedClassroom = null,
  */
 
 /*  Fetch all the Assignments (optionally: for the selected Classroom) from the
-    Education API. Implicit: the list of Assignments is limited to what's
-    available to the logged-in user.
+    Education API.
+    
+    Implicit: the list of Assignments is limited to what's available to the
+    logged-in user.
+    
+    NOTE: this fetches all assignments this user is a part of, whether they are
+    a teacher or a student!
     
     API notes: 
       GET /assignments/?classroom_id=123
@@ -691,7 +696,7 @@ Effect('wcc_teachers_createAssignment', ({ selectedProgram, selectedClassroom, a
           }
         }
  */
-Effect('wcc_editAssignment', ({ selectedAssignment, assignmentData, students = [], filters = {}, subjects = [] }) => {
+Effect('wcc_teachers_editAssignment', ({ selectedAssignment, assignmentData, students = [], filters = {}, subjects = [] }) => {
   //Sanity check
   if (!selectedAssignment || !assignmentData) return;
   
@@ -746,7 +751,7 @@ Effect('wcc_editAssignment', ({ selectedAssignment, assignmentData, students = [
     API notes:
       DELETE /assignments/12345
  */
-Effect('wcc_deleteAssignment', (selectedAssignment) => {
+Effect('wcc_teachers_deleteAssignment', (selectedAssignment) => {
   //Sanity check
   if (!selectedAssignment) return;
   
@@ -754,11 +759,11 @@ Effect('wcc_deleteAssignment', (selectedAssignment) => {
   
   return httpDelete(`/assignments/${selectedAssignment.id}`)
   .then((response) => {
-    if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_deleteAssignment): No response'; }
+    if (!response) { throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_deleteAssignment): No response'; }
     if (response.ok) {
       return Actions.wildcamClassrooms.setAssignmentsStatus(WILDCAMCLASSROOMS_DATA_STATUS.SUCCESS);
     }
-    throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_deleteAssignment): Invalid response';
+    throw 'ERROR (ducks/wildcam-classrooms/ducks/wcc_teachers_deleteAssignment): Invalid response';
   })
   .catch((err) => {
     Actions.wildcamClassrooms.setAssignmentsStatus(WILDCAMCLASSROOMS_DATA_STATUS.ERROR);

--- a/src/programs/darien/DarienProgram.jsx
+++ b/src/programs/darien/DarienProgram.jsx
@@ -18,6 +18,7 @@ import { Switch, Route } from 'react-router-dom';
 
 import DarienHome from './pages/DarienHome';
 import DarienEducators from './pages/DarienEducators';
+import DarienStudents from './pages/DarienStudents';
 import DarienMap from './pages/DarienMap';
 
 import DarienInfoEcology from './pages/info/DarienInfoEcology';
@@ -55,6 +56,7 @@ class DarienProgram extends React.Component {
             <Route exact path={`${props.match.url}/educators/intro`} component={DarienEducatorsIntro} />
             
             <Route path={`${props.match.url}/educators`} component={DarienEducators} />
+            <Route path={`${props.match.url}/students`} component={DarienStudents} />
             <Route path={`${props.match.url}/map`} component={DarienMap} />
             <Route path="*" component={Status404} />
           </Switch>

--- a/src/programs/darien/common/DarienNavi.jsx
+++ b/src/programs/darien/common/DarienNavi.jsx
@@ -15,7 +15,8 @@ function DarienNavi(props) {
     >
       <Anchor className="big link" path={`/wildcam-darien-lab`}>WildCam Darien Labs</Anchor>
       <Anchor className="link" path={`/wildcam-darien-lab/educators/intro`}>Intro</Anchor>
-      <Anchor className="link" path={`/wildcam-darien-lab/educators`}>Classrooms</Anchor>
+      <Anchor className="link" path={`/wildcam-darien-lab/educators`}>For Educators</Anchor>
+      <Anchor className="link" path={`/wildcam-darien-lab/students`}>For Students</Anchor>
       <Anchor className="link" path={`/wildcam-darien-lab/educators/ecology`}>Ecology</Anchor>
       <Anchor className="external link" href="https://www.hhmi.org/biointeractive/wildcam-darien" target="_blank" rel="noopener noreferrer">HHMI <ShareIcon size="xsmall" /></Anchor>
       <Anchor className="external link" href="https://www.zooniverse.org/projects/wildcam/wildcam-darien" target="_blank" rel="noopener noreferrer">Zooniverse <ShareIcon size="xsmall" /></Anchor>

--- a/src/programs/darien/pages/DarienEducators.jsx
+++ b/src/programs/darien/pages/DarienEducators.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
-import WildCamClassrooms from '../../../modules/wildcam-classrooms/containers/WildCamClassrooms';
+import WildCamForEducators from '../../../modules/wildcam-classrooms/containers/WildCamForEducators';
 import DarienNavi from '../common/DarienNavi';
 
 import Article from 'grommet/components/Article';
@@ -19,7 +19,7 @@ class DarienEducators extends React.Component {
     return (
       <Box>
         <DarienNavi />
-        <WildCamClassrooms
+        <WildCamForEducators
           selectedProgram={this.props.selectedProgram}
           location={this.props.match}
           history={this.props.history}

--- a/src/programs/darien/pages/DarienStudents.jsx
+++ b/src/programs/darien/pages/DarienStudents.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
-import WildCamStudents from '../../../modules/wildcam-classrooms/containers/WildCamStudents';
+import WildCamForStudents from '../../../modules/wildcam-classrooms/containers/WildCamForStudents';
 import DarienNavi from '../common/DarienNavi';
 
 import Article from 'grommet/components/Article';
@@ -19,7 +19,7 @@ class DarienStudents extends React.Component {
     return (
       <Box>
         <DarienNavi />
-        <WildCamStudents
+        <WildCamForStudents
           selectedProgram={this.props.selectedProgram}
           location={this.props.match}
           history={this.props.history}

--- a/src/programs/darien/pages/DarienStudents.jsx
+++ b/src/programs/darien/pages/DarienStudents.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Actions } from 'jumpstate';
+
+import WildCamStudents from '../../../modules/wildcam-classrooms/containers/WildCamStudents';
+import DarienNavi from '../common/DarienNavi';
+
+import Article from 'grommet/components/Article';
+import Box from 'grommet/components/Box';
+import Section from 'grommet/components/Section';
+
+class DarienStudents extends React.Component {
+  render() {
+    if (!this.props.selectedProgram) {
+      return null;
+    }
+    
+    return (
+      <Box>
+        <DarienNavi />
+        <WildCamStudents
+          selectedProgram={this.props.selectedProgram}
+          location={this.props.match}
+          history={this.props.history}
+          match={this.props.match}
+        />
+      </Box>
+    );
+  }
+};
+
+DarienStudents.defaultProps = {
+  history: null,
+  location: null,
+  match: null,
+  // ----------------
+  selectedProgram: null,
+};
+
+DarienStudents.propTypes = {
+  history: PropTypes.object,
+  location: PropTypes.object,
+  match: PropTypes.object,
+  // ----------------
+  selectedProgram: PropTypes.object,
+};
+
+function mapStateToProps(state) {
+  return {
+    selectedProgram: state.programs.selectedProgram,
+  };
+}
+
+export default connect(mapStateToProps)(DarienStudents);

--- a/src/programs/gorongosa/pages/GorongosaEducators.jsx
+++ b/src/programs/gorongosa/pages/GorongosaEducators.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Actions } from 'jumpstate';
 
-import WildCamClassrooms from '../../../modules/wildcam-classrooms/containers/WildCamClassrooms';
+import WildCamForEducators from '../../../modules/wildcam-classrooms/containers/WildCamForEducators';
 import GorongosaNavi from '../common/GorongosaNavi';
 
 import Article from 'grommet/components/Article';
@@ -19,7 +19,7 @@ class GorongosaEducators extends React.Component {
     return (
       <Box>
         <GorongosaNavi />
-        <WildCamClassrooms
+        <WildCamForEducators
           selectedProgram={this.props.selectedProgram}
           location={this.props.match}
           history={this.props.history}


### PR DESCRIPTION
## PR Overview
This PR updates WildCam Darien/the WildCam Lab components with the following:
- Students now have their own "For Students" page, which allows them see all Assignments they're a part of.
  - Not yet implemented: the ability for Students to actually start the Assignments they're a part of. This will require some external setup (i.e. enabling group work for WildCam Darien) and a new config setup (i.e. the ability for a Program to specify the URL where students need to perform Assignments).
- Teachers can now add/remove students from Assignments, and can remove students from Classrooms.
  - This was a feature I forgot to properly implement before.
  - Improvement needed: list of students added to Assignment should be retained after the transition to/from the Subjects selection feature.

### Status
Merging.
