### PR TITLE
Update PJC to 2.11.2 for compatibility with new Panoptes updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grommet": "~1.9.0",
     "jumpstate": "^2.2.2",
     "leaflet": "1.2.0",
-    "panoptes-client": "~2.11.0",
+    "panoptes-client": "~2.11.2",
     "papaparse": "~4.3.6",
     "prop-types": "~15.5.10",
     "query-string": "~5.0.0",


### PR DESCRIPTION
## PR Overview
This PR updates `panoptes-client` to v2.11.2, which is necessary for compatibility with one of Panoptes's upcoming updates. See https://github.com/zooniverse/panoptes-javascript-client/pull/103 for further details. (The short of it: if we don't update PJC, users won't be able to login after Panoptes updates its `doorkeeper`.)

**This PR is mostly for documentation.** PJC 2.11.2 has already been _installed and deployed_ as part of PR #136 (ongoing WildCam updates for HHMI), and I'll sort out the resulting merge conflict in that PR.

### Status
Merging.