### PR TITLE
WildCam Lab Classrooms - 2018(?!?) Rebuild - part 15

### DIFF
--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -166,6 +166,7 @@ class AssignmentsListForStudents extends React.Component {
                           <Paragraph size="small">{TEXT.LABELS.PROGRESS}: {classificationsCount} / {classificationsTarget}</Paragraph>
                           <ClassificationsDownloadButton
                             label={TEXT.ACTIONS.DOWNLOAD_MY_DATA}
+                            workflow_id={ass.workflowId}
                           />
                       </Box>
                     </td>

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -17,6 +17,7 @@ import { TEXT } from '../text.js';
 
 import StatusWorking from './StatusWorking';
 import ScrollToTopOnMount from '../../../containers/common/ScrollToTopOnMount';
+import ClassificationsDownloadButton from './ClassificationsDownloadButton';
 
 import Accordion from 'grommet/components/Accordion';
 import AccordionPanel from 'grommet/components/AccordionPanel';
@@ -163,6 +164,9 @@ class AssignmentsListForStudents extends React.Component {
                         >
                           <Button className="button" label={TEXT.ACTIONS.START_ASSIGNMENT + ' '} href={urlToAssignment} target="_blank" rel="noopener noreferrer" icon={<LinkNextIcon size="small" />} reverse={true} />
                           <Paragraph size="small">{TEXT.LABELS.PROGRESS}: {classificationsCount} / {classificationsTarget}</Paragraph>
+                          <ClassificationsDownloadButton
+                            
+                          />
                       </Box>
                     </td>
                   </TableRow>

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -165,7 +165,7 @@ class AssignmentsListForStudents extends React.Component {
                           <Button className="button" label={TEXT.ACTIONS.START_ASSIGNMENT + ' '} href={urlToAssignment} target="_blank" rel="noopener noreferrer" icon={<LinkNextIcon size="small" />} reverse={true} />
                           <Paragraph size="small">{TEXT.LABELS.PROGRESS}: {classificationsCount} / {classificationsTarget}</Paragraph>
                           <ClassificationsDownloadButton
-                            
+                            label={TEXT.ACTIONS.DOWNLOAD_MY_DATA}
                           />
                       </Box>
                     </td>

--- a/src/modules/wildcam-classrooms/components/ClassificationsDownloadButton.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassificationsDownloadButton.jsx
@@ -1,0 +1,65 @@
+/*
+ClassificationsDownloadButton
+-----------------------------
+
+Component for viewing, editing, or deleting a single assignment.
+
+--------------------------------------------------------------------------------
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Button from 'grommet/components/Button';
+import DownloadButton from 'grommet/components/icons/base/Download';
+
+class ClassificationsDownloadButton extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+    };
+  }
+  
+  // ----------------------------------------------------------------
+  
+  componentDidMount() {
+    this.initialise(this.props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.initialise(nextProps);
+  }
+  
+  initialise(props = this.props) {
+  }
+
+  render() {
+    const props = this.props;
+    const state = this.state;
+    
+    return (
+      <Button
+        className="classifications-download-button button"
+        icon={<DownloadButton size="small" />}
+        label="DOWNLOAD ASSIGNMENT"
+        onClick={this.onClick.bind(this)}
+      />
+    );
+
+    return null;
+  }
+  
+  onClick() {
+    console.log('+++ CLICK');
+  }
+};
+
+/*
+--------------------------------------------------------------------------------
+ */
+
+ClassificationsDownloadButton.defaultProps = {};
+
+ClassificationsDownloadButton.propTypes = {};
+
+export default ClassificationsDownloadButton;

--- a/src/modules/wildcam-classrooms/components/ClassificationsDownloadButton.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassificationsDownloadButton.jsx
@@ -10,6 +10,13 @@ Component for viewing, editing, or deleting a single assignment.
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import superagent from 'superagent';
+import superagentJsonapify from 'superagent-jsonapify';
+import apiClient from 'panoptes-client/lib/api-client';
+import { config } from '../../../lib/config';
+
+superagentJsonapify(superagent);
+
 import Button from 'grommet/components/Button';
 import DownloadButton from 'grommet/components/icons/base/Download';
 
@@ -37,12 +44,15 @@ class ClassificationsDownloadButton extends React.Component {
     const props = this.props;
     const state = this.state;
     
+    const icon = <DownloadButton size="small" />;
+    const onClick = this.onClick.bind(this);
+    
     return (
       <Button
         className="classifications-download-button button"
-        icon={<DownloadButton size="small" />}
-        label="DOWNLOAD ASSIGNMENT"
-        onClick={this.onClick.bind(this)}
+        icon={icon}
+        label={props.label}
+        onClick={onClick}
       />
     );
 
@@ -51,6 +61,28 @@ class ClassificationsDownloadButton extends React.Component {
   
   onClick() {
     console.log('+++ CLICK');
+    this.fetchData();
+  }
+  
+  fetchData() {
+    const props = this.props;
+    
+    //const request = superagent.get(`${config.root}${endpoint}`)
+    //  .set('Content-Type', 'application/json')
+    //  .set('Authorization', apiClient.headers.Authorization);
+    
+    const args = {};
+    if (props.workflow_id) args.workflow_id = props.workflow_id;
+    
+    console
+
+    apiClient.type('classifications').get(args)
+    
+      .then((data) => {
+        console.log(data);
+        return data;
+      })
+      .catch(error => this.handleError(error));
   }
 };
 
@@ -58,8 +90,14 @@ class ClassificationsDownloadButton extends React.Component {
 --------------------------------------------------------------------------------
  */
 
-ClassificationsDownloadButton.defaultProps = {};
+ClassificationsDownloadButton.defaultProps = {
+  label: '',
+  workflow_id: undefined,
+};
 
-ClassificationsDownloadButton.propTypes = {};
+ClassificationsDownloadButton.propTypes = {
+  label: PropTypes.string,
+  workflow_id: PropTypes.string,
+};
 
 export default ClassificationsDownloadButton;

--- a/src/modules/wildcam-classrooms/text.en.js
+++ b/src/modules/wildcam-classrooms/text.en.js
@@ -17,6 +17,7 @@ const TEXT_EN = {
     CREATE_NEW_CLASSROOM: 'Create new classroom',
     CREATE_NEW_ASSIGNMENT: 'Create new assignment',
     DELETE: 'Delete',  //Generic "delete item" action.
+    DOWNLOAD_MY_DATA: 'My Data',
     EDIT: 'Edit',  //Generic "edit item" action.
     HELP: 'Help',  //Generic "help" action, for How Tos, Guides, Instructions, etc.
     NEXT: 'Next',  //Generic "next" action, e.g. to go to the next step in a tutorial.

--- a/src/modules/wildcam-classrooms/text.es.js
+++ b/src/modules/wildcam-classrooms/text.es.js
@@ -17,6 +17,7 @@ const TEXT_ES = {
     CREATE_NEW_CLASSROOM: 'Crear un salón de clases nuevo',
     CREATE_NEW_ASSIGNMENT: 'Crear una nueva asignaciones',
     DELETE: 'Borrar',  //Generic "delete item" action.
+    DOWNLOAD_MY_DATA: 'Mis datos',
     EDIT: 'Editar',  //Generic "edit item" action.
     HELP: 'Ayuda',  //Generic "help" action, for How Tos, Guides, Instructions, etc.
     NEXT: 'Siguiente',  //Generic "next" action, e.g. to go to the next step in a tutorial.

--- a/src/programs/darien/wildcam-darien.classroom-config.js
+++ b/src/programs/darien/wildcam-darien.classroom-config.js
@@ -13,8 +13,8 @@ import { env } from '../../lib/config';
 const classroomConfig = {
   forStudents: {
     urlToAssignment: (env === 'production')
-      ? 'https://www.zooniverse.org/projects/wildcam/wildcam-darien/classify?workflow={WORKFLOW_ID}'
-      : 'https://www.zooniverse.org/projects/wildcam/wildcam-darien/classify?workflow={WORKFLOW_ID}',  //TODO: find the staging equivalent for WildCam Darien
+      ? 'https://www.zooniverse.org/projects/wildcam/wildcam-darien/classify?workflow={WORKFLOW_ID}&classroom=1'
+      : 'https://www.zooniverse.org/projects/wildcam/wildcam-darien/classify?workflow={WORKFLOW_ID}&classroom=1',  //TODO: find the staging equivalent for WildCam Darien
   },
   forEducators: {
     extraInfoFor: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
 
   devServer: {
     contentBase: path.join(__dirname, '/src/'),
+    disableHostCheck: true,  //Allow access using custom host names, e.g. local.zooniverse.org:3998, which is necessary for testing certain API calls.
     // hot: true,
     inline: true,
     stats: {


### PR DESCRIPTION
## PR Overview
This PR focuses on adding a basic "Download My Classifications" button to Student Assignments on WildCam Lab programs.

- The "Download My Classifications" button will download _(in chunks)_ all of a (logged-in) user's Classifications from a single Workflow (i.e. assignment)
  - This CSV is still somewhat basic, and lacks any map information - a separate call to Carto's DB needs to be made and manually joined to the data from Classifications. Good luck with the load, eh!
- ❗️ EXTERNAL BUGFIX: See zooniverse/Panoptes-Front-End#5256 and zooniverse/Panoptes-Front-End#5259 for a massive bugfix that prevented non-admin/non-project owner users from working on an Assignment on PFE.
  - This error was previous undetected on WildCam Darien Lab because I, Shaun, was always logged in with my account, that _was_ an admin/project owner. 😞 
- ❗️ To access Assignments, two new things must be done.
  - the Project must have `'wildcam classroom'` added to its experimental tools
  - the URL to the classroom must look like... `https://www.zooniverse.org/projects/wildcam/wildcam-darien/classify?workflow=8752&classroom=1`
