### PR TITLE
WildCam Lab 2019 pt 5 - Add Reminders to "Start Assignment"

### DIFF
--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -170,13 +170,13 @@ class AssignmentsListForStudents extends React.Component {
                             ? <Button className="button" label={TEXT.ACTIONS.START_ASSIGNMENT + ' '} target="_blank" rel="noopener noreferrer" icon={<LinkNextIcon size="small" />} reverse={true} onClick={() => { this.setState({ showLoginReminder: ass.id }) }} />
                             : <Button className="button" label={TEXT.ACTIONS.START_ASSIGNMENT + ' '} href={urlToAssignment} target="_blank" rel="noopener noreferrer" icon={<LinkNextIcon size="small" />} reverse={true} />
                           }
-                        
+
                           {(this.state.showLoginReminder !== ass.id) ? null :
-                            <Paragraph size="small">
-                              Please remember to login at zooniverse.org before starting your assignment. Click on "Start Assignment" again once you're ready.
+                            <Paragraph className="reminder-block" size="small" margin="none">
+                              {TEXT.HELPERS.REMEMBER_TO_LOGIN}
                             </Paragraph>
                           }
-                        
+
                           <Paragraph size="small">{TEXT.LABELS.PROGRESS}: {classificationsCount} / {classificationsTarget}</Paragraph>
 
                           <ClassificationsDownloadButton

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -43,6 +43,10 @@ import {
 class AssignmentsListForStudents extends React.Component {
   constructor() {
     super();
+  
+    this.state = {
+      showLoginReminder: undefined,  // undefined if reminder isn't being show; assignment ID if one assignment has been selected.
+    };
   }
   
   componentDidMount() {
@@ -162,8 +166,19 @@ class AssignmentsListForStudents extends React.Component {
                           justify="end"
                           align="center"
                         >
-                          <Button className="button" label={TEXT.ACTIONS.START_ASSIGNMENT + ' '} href={urlToAssignment} target="_blank" rel="noopener noreferrer" icon={<LinkNextIcon size="small" />} reverse={true} />
+                          {(!this.state.showLoginReminder)
+                            ? <Button className="button" label={TEXT.ACTIONS.START_ASSIGNMENT + ' '} target="_blank" rel="noopener noreferrer" icon={<LinkNextIcon size="small" />} reverse={true} onClick={() => { this.setState({ showLoginReminder: ass.id }) }} />
+                            : <Button className="button" label={TEXT.ACTIONS.START_ASSIGNMENT + ' '} href={urlToAssignment} target="_blank" rel="noopener noreferrer" icon={<LinkNextIcon size="small" />} reverse={true} />
+                          }
+                        
+                          {(this.state.showLoginReminder !== ass.id) ? null :
+                            <Paragraph size="small">
+                              Please remember to login at zooniverse.org before starting your assignment. Click on "Start Assignment" again once you're ready.
+                            </Paragraph>
+                          }
+                        
                           <Paragraph size="small">{TEXT.LABELS.PROGRESS}: {classificationsCount} / {classificationsTarget}</Paragraph>
+
                           <ClassificationsDownloadButton
                             label={TEXT.ACTIONS.DOWNLOAD_MY_DATA}
                             transformData={props.transformData}

--- a/src/modules/wildcam-classrooms/text.en.js
+++ b/src/modules/wildcam-classrooms/text.en.js
@@ -57,6 +57,7 @@ const TEXT_EN = {
     STUDENTS_ASSIGNMENT_LIST: 'Click on the arrow next to the assignment name to view the due date and instructions.',
     EDUCATORS_JOIN_URL: 'Send this URL to all the students you want to join this classroom. But first, make sure your students have a Zooniverse account and are logged in before they click the link to join!',
     SUBJECTS_LIST: 'Choose the type and quantity of trail camera photos you want your students to identify.',
+    REMEMBER_TO_LOGIN: 'Please remember to login at zooniverse.org before starting your assignment. Click on "Start Assignment" again once you\'re ready.',
   },
   LABELS: {
     JOIN_URL: 'Join URL',

--- a/src/modules/wildcam-classrooms/text.es.js
+++ b/src/modules/wildcam-classrooms/text.es.js
@@ -57,6 +57,7 @@ const TEXT_ES = {
     STUDENTS_ASSIGNMENT_LIST: 'Haga clic en la flecha al lado del nombre de la asignación para ver la fecha de vencimiento y las instrucciones.',
     EDUCATORS_JOIN_URL: 'Envíe esta URL a todos los estudiantes a los que desea unirse a este aula. ¡Pero primero, asegúrese de que sus estudiantes tengan una cuenta de Zooniverse y que hayan iniciado sesión antes de hacer clic en el enlace para unirse!',
     SUBJECTS_LIST: 'Elija el tipo y la cantidad de fotos de la cámara de fotos que desea que los estudiantes identifiquen.',
+    REMEMBER_TO_LOGIN: 'Por favor, recuerde iniciar sesión en zooniverse.org antes de comenzar su tarea. Haga clic en "Comenzar la asignación" de nuevo una vez que esté listo.',
   },
   LABELS: {
     JOIN_URL: 'Únete a la URL',

--- a/src/styles/components/wildcam-classrooms.styl
+++ b/src/styles/components/wildcam-classrooms.styl
@@ -88,3 +88,9 @@ BORDER_SIZE = 0.25rem
   .helper-text
     font-size: 0.8em
     font-style: italic
+
+  .reminder-block
+    background: HIGHLIGHT_DARK
+    color: BACKGROUND
+    padding: 0.5em
+    margin-top: 0.5em


### PR DESCRIPTION
## PR Overview

In the Student's Assignments list, the first time a user clicks on any "Start Assignment" button, they are provided a reminder to to login at `zooniverse.org` before starting the assignment.

![Screen Shot 2019-05-01 at 16 12 09](https://user-images.githubusercontent.com/13952701/57024217-003efe80-6c2c-11e9-9554-6392dbbf7e85.png)

After that reminder is show, all "Start Assignment" buttons take the user to their assignments, as usual.

### Status

Merging