### PR TITLE
Fix exports

### DIFF
--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -129,7 +129,7 @@ function AstroClassroomsTable(props) {
                           type="button"
                           className="manager-table__button--as-link"
                           plain={true}
-                          onClick={props.showExportModal.bind(null, assignment, classroom)}
+                          onClick={calculatedCompleteness !== 0 ? props.showExportModal.bind(null, assignment, classroom) : null}
                         >
                           Export Data{' '}
                           <i className="fa fa-arrow-down" aria-hidden="true" />

--- a/src/components/astro/AstroClassroomsTable.jsx
+++ b/src/components/astro/AstroClassroomsTable.jsx
@@ -129,10 +129,7 @@ function AstroClassroomsTable(props) {
                           type="button"
                           className="manager-table__button--as-link"
                           plain={true}
-                          onClick={calculatedCompleteness !== 0 ?
-                            props.showExportModal.bind(null, assignment, classroom) :
-                            null
-                          }
+                          onClick={props.showExportModal.bind(null, assignment, classroom)}
                         >
                           Export Data{' '}
                           <i className="fa fa-arrow-down" aria-hidden="true" />

--- a/src/components/astro/ExportModal.jsx
+++ b/src/components/astro/ExportModal.jsx
@@ -46,7 +46,8 @@ function ExportModal({
     toExport.classroom &&
     toExport.assignment &&
     requestedExports[toExport.classroom.id] &&
-    requestedExports[toExport.classroom.id].workflow_id.toString() === toExport.assignment.workflowId;
+    requestedExports[toExport.classroom.id].exportable_id &&
+    requestedExports[toExport.classroom.id].exportable_id.toString() === toExport.assignment.workflowId;
   const disableButton = noExport || fetching || pending;
   const success = Object.keys(caesarExport).length > 0 && caesarExportStatus === CAESAR_EXPORTS_STATUS.SUCCESS;
   const assignmentName = (toExport.assignment && toExport.assignment.name) ? prepStringForFilename(toExport.assignment.name) : null;

--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -22,8 +22,6 @@ class AstroClassroomsTableContainer extends React.Component {
 
     this.handleRequestForNewExport = this.handleRequestForNewExport.bind(this);
     this.onExportModalClose = this.onExportModalClose.bind(this);
-    this.handleRequestForNewExport = this.handleRequestForNewExport.bind(this);
-    this.onExportModalClose = this.onExportModalClose.bind(this);
     this.showExportModal = this.showExportModal.bind(this);
     this.transformData = this.transformData.bind(this);
   }
@@ -44,7 +42,8 @@ class AstroClassroomsTableContainer extends React.Component {
 
     if (Object.keys(this.props.requestedExports).length > 0 &&
         this.props.requestedExports[classroom.id] &&
-        this.props.requestedExports[classroom.id].workflow_id.toString() === assignment.workflowId) {
+        this.props.requestedExports[classroom.id].exportable_id &&
+        this.props.requestedExports[classroom.id].exportable_id.toString() === assignment.workflowId) {
       this.checkPendingExport(assignment, classroom, this.props.requestedExports[classroom.id].id);
     } else {
       this.checkExportExistence(assignment, classroom)

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -188,10 +188,8 @@ Effect('createCaesarExport', (data) => {
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/caesarExports/getCaesarExport): No response'; }
       if (response.ok && response.body) {
-        console.log('response.ok', response.body)
         const responseData = response.body;
         if (responseData.status === 'pending') {
-          console.log('pending status')
           const requestedExport = { [data.classroom.id]: responseData };
           Actions.caesarExports.setRequestedExports(requestedExport);
           Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.PENDING);

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -80,7 +80,7 @@ Effect('getCaesarExports', (data) => {
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
     .query({
-      requested_data: 'reductions',
+      requested_data: 'user_reductions',
       subgroup: data.classroom.zooniverseGroupId
     })
     .then((response) => {
@@ -182,14 +182,16 @@ Effect('createCaesarExport', (data) => {
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
     .send({
-      requested_data: 'reductions',
+      requested_data: 'user_reductions',
       subgroup: data.classroom.zooniverseGroupId
     })
     .then((response) => {
       if (!response) { throw 'ERROR (ducks/caesarExports/getCaesarExport): No response'; }
       if (response.ok && response.body) {
+        console.log('response.ok', response.body)
         const responseData = response.body;
         if (responseData.status === 'pending') {
+          console.log('pending status')
           const requestedExport = { [data.classroom.id]: responseData };
           Actions.caesarExports.setRequestedExports(requestedExport);
           Actions.caesarExports.setStatus(CAESAR_EXPORTS_STATUS.PENDING);

--- a/src/ducks/caesar-exports.js
+++ b/src/ducks/caesar-exports.js
@@ -80,7 +80,7 @@ Effect('getCaesarExports', (data) => {
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
     .query({
-      requested_data: 'user_reductions',
+      requested_data: 'subject_reductions',
       subgroup: data.classroom.zooniverseGroupId
     })
     .then((response) => {
@@ -182,7 +182,7 @@ Effect('createCaesarExport', (data) => {
     .set('Content-Type', 'application/json')
     .set('Authorization', apiClient.headers.Authorization)
     .send({
-      requested_data: 'user_reductions',
+      requested_data: 'subject_reductions',
       subgroup: data.classroom.zooniverseGroupId
     })
     .then((response) => {


### PR DESCRIPTION
Caesar's API for requesting data exports has changed which is the likely source of the issues in #148. This is a partial fix to the issue. I've updated the requests to use `subject_reductions` in the request payload as well as changed `workflow_id` to `exportable_id` in the store. 

I'm unsure if anymore client side changes need to be made, but there are some possible server side bugs now being exposed now that the request is properly being made. See https://github.com/zooniverse/caesar/issues/859