### PR TITLE
WildCam Lab 2019 pt9 - WildCam Gorongosa Lab CSV

### DIFF
--- a/src/programs/gorongosa/wildcam-gorongosa.map-config.js
+++ b/src/programs/gorongosa/wildcam-gorongosa.map-config.js
@@ -32,8 +32,8 @@ const mapConfig = {
         SELECT
           cam.veg_type,
           cam.human_type AS "human_structure",
-          cam.dist_humans_m,
-          cam.dist_water_m,
+          cam.dist_humans_m AS distance_human_m,
+          cam.dist_water_m AS distance_water_m,
           cam.water_type,
           cam.latitude,
           cam.longitude,
@@ -45,7 +45,7 @@ const mapConfig = {
           SELECT
             sbj.subject_id AS image_id,
             sbj.camera,
-            sbj.location AS img_url,
+            sbj.location AS image_url,
             sbj.month,
             sbj.year,
             sbj.season,
@@ -498,8 +498,50 @@ const mapConfig = {
   //Misc stuff related to the program
   'program': {
     dataGuideURL: '/#/wildcam-gorongosa-lab/explorers/data-guide/',
-    transformDownloadData: undefined
+    transformDownloadData: function (csvData) {
+      if (csvData && csvData.data && csvData.data.length > 0 && csvData.errors.length === 0) {
+        return Promise.resolve(transformGorongosaDownloadData(csvData));
+      }
+
+      if (csvData && csvData.errors.length > 0) {
+        return Promise.reject(csvData.errors[0].message);
+      }
+
+      return Promise.resolve(null);      
+    }
   },
 };
+
+function transformGorongosaDownloadData (csvData) {
+  let output = '';
+  
+  const tgtColumns = [
+    "image_id","camera","longitude","latitude","date","month","year","season","time_period","veg_type","human_structure","distance_human_m","water_type","distance_water_m","species","species_count","percentage_resting","percentage_standing","percentage_moving","percentage_eating","percentage_interacting","young_present","horns","image_url"
+  ];
+  const srcColumns = csvData.data[0];
+  
+  output = tgtColumns.map(str => csvStr(str)).join(',') + '\n';
+  
+  for (let i = 1; i < csvData.data.length; i ++) {
+    let srcRow = csvData.data[i];
+    let tgtRow = [];
+    
+    if (srcRow.length < tgtColumns.length) continue;  // Ignore empty rows
+    
+    tgtColumns.forEach(tgtCol => {
+      const cellIndex = srcColumns.findIndex(i => i===tgtCol);
+      const cell = (cellIndex >= 0) ? srcRow[cellIndex] : '';
+      tgtRow.push(cell);
+    });
+    
+    output += tgtRow.map(str => csvStr(str)).join(',') + '\n';
+  }
+  
+  return output;
+}
+
+function csvStr(str) {
+  return '"' + str.replace(/"/g, '""') + '"';
+}
 
 export default mapConfig;

--- a/src/programs/gorongosa/wildcam-gorongosa.map-config.js
+++ b/src/programs/gorongosa/wildcam-gorongosa.map-config.js
@@ -31,7 +31,7 @@ const mapConfig = {
       'selectForDownload': `
         SELECT
           cam.veg_type,
-          cam.human_type,
+          cam.human_type AS "human_structure",
           cam.dist_humans_m,
           cam.dist_water_m,
           cam.water_type,
@@ -43,7 +43,24 @@ const mapConfig = {
         INNER JOIN
           (
           SELECT
-            sbj.camera, sbj.location, sbj.month, sbj.year, sbj.season, sbj.time_period, sbj.timeutc, sbj.dateutc, sbj.gorongosa_id, agg.species, agg.num_classifications
+            sbj.subject_id AS image_id,
+            sbj.camera,
+            sbj.location AS img_url,
+            sbj.month,
+            sbj.year,
+            sbj.season,
+            sbj.time_period,
+            sbj.dateutc AS "date",
+            sbj.gorongosa_id,
+            agg.species,
+            agg.num_classifications AS "species_count",
+            agg.percentage_behaviour_resting AS "percentage_resting",
+            agg.percentage_behaviour_standing AS "percentage_standing",
+            agg.percentage_behaviour_moving AS "percentage_moving",
+            agg.percentage_behaviour_eating AS "percentage_eating",
+            agg.percentage_behaviour_interacting AS "percentage_interacting",
+            agg.most_likely_are_there_any_young_present AS "young_present",
+            agg.most_likely_do_you_see_any_horns AS "horns" 
           FROM
             wildcam_gorongosa_subjects_201601_16000 AS sbj
           INNER JOIN


### PR DESCRIPTION
## PR Overview

This PR updates the CSV download for WildCam Gorongosa Lab (the **Map** downloads, not the Assignments downloads). Without this PR, the downloaded CSVs are missing a few columns (behaviour, etc), have different column names ('location' instead of 'image_url'), and columns that are out of order.

The first two issues were caused by me having previously taken the initiative to streamline the Gorongosa CSV downloads to match Darien's CSV downloads. Whoops, that was a mistake of over-optimisation without checking user reqs. The third issue is caused by... a wizard did it. I have no idea why the SQL results from Carto have the columns in a semi-random order.

### Status

Merging and deploying.