### PR TITLE
WildCam Lab 2019 pt11 - Fix "Pulling too many Assignments" Bug

### DIFF
--- a/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentForm.jsx
@@ -110,6 +110,8 @@ class AssignmentForm extends React.Component {
     const assignment_id = (props.match && props.match.params)
       ? props.match.params.assignment_id : undefined;
     
+    const selectedProgram = props.selectedProgram;
+    
     //Sanity check
     if (!classroom_id) return;
     const selectedClassroom = props.classroomsList &&
@@ -126,7 +128,7 @@ class AssignmentForm extends React.Component {
     //If we don't have a list of assignments yet, fetch it.
     //Redundancy Check: prevent infinite loop, only trigger once.
     if (props.assignmentsStatus === WILDCAMCLASSROOMS_DATA_STATUS.IDLE) {
-      Actions.wcc_fetchAssignments({ selectedClassroom });
+      Actions.wcc_fetchAssignments({ selectedProgram, selectedClassroom });
     } else {
       this.initialise_partTwo(props, classroom_id, assignment_id, props.assignmentsList);
     }

--- a/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
+++ b/src/modules/wildcam-classrooms/components/AssignmentsListForStudents.jsx
@@ -32,6 +32,7 @@ import TableRow from 'grommet/components/TableRow';
 
 import LinkNextIcon from 'grommet/components/icons/base/LinkNext';
 
+import { PROGRAMS_PROPTYPES, PROGRAMS_INITIAL_STATE } from '../../../ducks/programs';
 import {
   WILDCAMCLASSROOMS_COMPONENT_MODES as MODES,
   WILDCAMCLASSROOMS_DATA_STATUS,
@@ -50,7 +51,7 @@ class AssignmentsListForStudents extends React.Component {
   }
   
   componentDidMount() {
-    Actions.wcc_fetchAssignments({});
+    Actions.wcc_fetchAssignments({ selectedProgram: this.props.selectedProgram });
   }
   
   // ----------------------------------------------------------------
@@ -207,6 +208,7 @@ class AssignmentsListForStudents extends React.Component {
 AssignmentsListForStudents.defaultProps = {
   transformData: null,
   urlToAssignment: '',  //Passed from parent.
+  selectedProgram: PROGRAMS_INITIAL_STATE.selectedProgram,  //Passed from parent.
   // ----------------
   ...WILDCAMCLASSROOMS_INITIAL_STATE,
   // ----------------
@@ -219,6 +221,7 @@ AssignmentsListForStudents.propTypes = {
     PropTypes.object
   ]),
   urlToAssignment: PropTypes.string,
+  selectedProgram: PROGRAMS_PROPTYPES.selectedProgram,
   // ----------------
   ...WILDCAMCLASSROOMS_PROPTYPES,
   // ----------------

--- a/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
+++ b/src/modules/wildcam-classrooms/components/ClassroomForm.jsx
@@ -103,6 +103,8 @@ class ClassroomForm extends React.Component {
     const classroom_id = (props.match && props.match.params)
       ? props.match.params.classroom_id : undefined;
     
+    const selectedProgram = props.selectedProgram;
+    
     //Create a new classroom
     if (!classroom_id) {  //Note: there should never be classroom_id === 0 or ''
       this.setState({ view: VIEWS.CREATE_NEW });
@@ -126,7 +128,7 @@ class ClassroomForm extends React.Component {
         
         //...and if either the selected classroom changed, or the assignments haven't been fetched yet, fetch those assignments. 
         if (shouldFetchAssignments) {
-          Actions.wcc_fetchAssignments({ selectedClassroom });
+          Actions.wcc_fetchAssignments({ selectedProgram, selectedClassroom });
         }
         
         //View update

--- a/src/modules/wildcam-classrooms/containers/WildCamForStudents.jsx
+++ b/src/modules/wildcam-classrooms/containers/WildCamForStudents.jsx
@@ -81,6 +81,7 @@ class WildCamForStudents extends React.Component {
         )}
         
         <AssignmentsListForStudents
+          selectedProgram={props.selectedProgram}
           transformData={(props.classroomConfig && props.classroomConfig.forStudents && props.classroomConfig.forStudents.transformClassificationsDownload)
             ? props.classroomConfig.forStudents.transformClassificationsDownload
             : null

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -517,7 +517,7 @@ Effect('wcc_teachers_refreshData', ({ selectedProgram, selectedClassroom = null,
     
     //Also restore assignments, if any apply.
     if (retrieved_selectedClassroom && saved_selectedAssignment_id) {
-      return Actions.wcc_fetchAssignments({ selectedClassroom: retrieved_selectedClassroom })
+      return Actions.wcc_fetchAssignments({ selectedProgram, selectedClassroom: retrieved_selectedClassroom })
       .then((body) => {
         const assignments = body.data;
         
@@ -560,13 +560,16 @@ Effect('wcc_teachers_refreshData', ({ selectedProgram, selectedClassroom = null,
     API notes: 
       GET /assignments/?classroom_id=123
  */
-Effect('wcc_fetchAssignments', ({ selectedClassroom }) => {
+Effect('wcc_fetchAssignments', ({ selectedProgram, selectedClassroom }) => {
   //NOTE: if selectedClassroom isn't specified, this will pull a list of ALL
   //Assignments belonging to the user. This is useful in certain circumstances.
   //However, do note that the argument needs to be an empty object, e.g.
   //  `Actions.wcc_fetchAssignments({})`
   
   const classroom_id = (selectedClassroom) ? selectedClassroom.id : undefined;
+  const program_id = (selectedProgram) ? selectedProgram.id : undefined;
+  
+  console.log('+++ PROGRAM: ', selectedProgram);
   
   Actions.wildcamClassrooms.resetAssignments();
   Actions.wildcamClassrooms.setAssignmentsStatus(WILDCAMCLASSROOMS_DATA_STATUS.FETCHING);

--- a/src/modules/wildcam-classrooms/ducks/index.js
+++ b/src/modules/wildcam-classrooms/ducks/index.js
@@ -569,12 +569,10 @@ Effect('wcc_fetchAssignments', ({ selectedProgram, selectedClassroom }) => {
   const classroom_id = (selectedClassroom) ? selectedClassroom.id : undefined;
   const program_id = (selectedProgram) ? selectedProgram.id : undefined;
   
-  console.log('+++ PROGRAM: ', selectedProgram);
-  
   Actions.wildcamClassrooms.resetAssignments();
   Actions.wildcamClassrooms.setAssignmentsStatus(WILDCAMCLASSROOMS_DATA_STATUS.FETCHING);
   
-  return get('/assignments/', [{ classroom_id }])
+  return get('/assignments/', [{ program_id, classroom_id }])
   
   .then((response) => {
     if (!response) { throw 'ERROR (wildcam-classrooms/ducks/wcc_fetchAssignments): No response'; }


### PR DESCRIPTION
## PR Overview

This PR fixes an issue where WildCam Classrooms kept fetching ALL assignments from the `/assignments` endpoint. This patch makes sure that only Assignments from the current Program are fetched.

### Status

Ready to go