### PR TITLE
Fix WildCam Gorongosa Lab's SQL Queries

### DIFF
--- a/src/programs/gorongosa/wildcam-gorongosa.map-config.js
+++ b/src/programs/gorongosa/wildcam-gorongosa.map-config.js
@@ -25,7 +25,37 @@ const mapConfig = {
     },
     'queries': {
       //For each camera, show how many (filtered) results are available.
-      'selectCameraCount': 'SELECT cam.*, COUNT(sbjagg.*) as count FROM wildcam_gorongosa_cameras_201601 AS cam LEFT JOIN (SELECT sbj.camera, sbj.location, sbj.dateutc, sbj.season, sbj.time_period, agg.species, agg.subject_id FROM wildcam_gorongosa_subjects_201601_16000 AS sbj INNER JOIN wildcam_gorongosa_aggregations_201603a AS agg ON sbj.subject_id = agg.subject_id) AS sbjagg ON cam.id = sbjagg.camera {WHERE} GROUP BY cam.cartodb_id ORDER BY count DESC',
+      'selectCameraCount': `
+        SELECT
+          cam.*,
+          COUNT(sbjagg.*) as count
+        FROM
+          wildcam_gorongosa_cameras_201601 AS cam
+        LEFT JOIN
+          (
+          SELECT
+            sbj.camera,
+            sbj.location,
+            sbj.dateutc,
+            sbj.season,
+            sbj.time_period,
+            agg.species,
+            agg.subject_id
+          FROM
+            wildcam_gorongosa_subjects_201601_16000 AS sbj
+          INNER JOIN
+            wildcam_gorongosa_aggregations_201603a AS agg
+          ON
+            sbj.subject_id = agg.subject_id
+          ) AS sbjagg
+        ON
+          cam.id = sbjagg.camera
+        {WHERE}
+        GROUP BY
+          cam.cartodb_id
+        ORDER BY
+          count DESC
+      `,
       
       //Get all the details for all the (filtered) results.
       'selectForDownload': `
@@ -74,7 +104,40 @@ const mapConfig = {
       `,
       
       //Get all the minimum Subject details for all the (filtered) results. Has Order By and Limit clauses.
-      'selectForAssignment': 'SELECT sbjagg.subject_id, sbjagg.location FROM wildcam_gorongosa_cameras_201601 AS cam INNER JOIN (SELECT sbj.subject_id, sbj.camera, sbj.location, sbj.month, sbj.year, sbj.season, sbj.time_period, sbj.timeutc, sbj.dateutc, sbj.gorongosa_id, agg.species, agg.num_classifications FROM wildcam_gorongosa_subjects_201601_16000 AS sbj INNER JOIN wildcam_gorongosa_aggregations_201603a AS agg ON sbj.subject_id = agg.subject_id) AS sbjagg ON cam.id = sbjagg.camera {WHERE} {ORDER} {LIMIT}',
+      'selectForAssignment': `
+        SELECT
+          sbjagg.subject_id,
+          sbjagg.location
+        FROM
+          wildcam_gorongosa_cameras_201601 AS cam
+        INNER JOIN
+          (
+          SELECT
+            sbj.subject_id,
+            sbj.camera,
+            sbj.location,
+            sbj.month,
+            sbj.year,
+            sbj.season,
+            sbj.time_period,
+            sbj.timeutc,
+            sbj.dateutc,
+            sbj.gorongosa_id,
+            agg.species,
+            agg.num_classifications
+          FROM
+            wildcam_gorongosa_subjects_201601_16000 AS sbj
+          INNER JOIN
+            wildcam_gorongosa_aggregations_201603a AS agg
+          ON
+            sbj.subject_id = agg.subject_id
+          ) AS sbjagg
+        ON
+          cam.id = sbjagg.camera
+        {WHERE}
+        {ORDER}
+        {LIMIT}
+      `,
       
       //Get all subjects, with camera data.
       'selectAllSubjects': `
@@ -105,7 +168,37 @@ const mapConfig = {
       `,
       
       //Select all the photos from a specific camera. Similar to selectForDownload
-      'selectCameraData': 'SELECT DISTINCT(sbjagg.location) FROM wildcam_gorongosa_cameras_201601 AS cam INNER JOIN (SELECT sbj.camera, sbj.location, sbj.month, sbj.year, sbj.season, sbj.time_period, sbj.timeutc, sbj.dateutc, sbj.gorongosa_id, agg.species FROM wildcam_gorongosa_subjects_201601_16000 AS sbj INNER JOIN wildcam_gorongosa_aggregations_201603a AS agg ON sbj.subject_id = agg.subject_id) AS sbjagg ON cam.id = sbjagg.camera {WHERE}',
+      'selectCameraData': `
+        SELECT
+          DISTINCT(sbjagg.location)
+        FROM
+          wildcam_gorongosa_cameras_201601 AS cam
+        INNER JOIN
+          (
+          SELECT
+            sbj.camera,
+            sbj.location,
+            sbj.month,
+            sbj.year,
+            sbj.season,
+            sbj.time_period,
+            sbj.timeutc,
+            sbj.dateutc,
+            sbj.gorongosa_id,
+            agg.species
+          FROM
+            wildcam_gorongosa_subjects_201601_16000 AS sbj
+          INNER JOIN
+            wildcam_gorongosa_aggregations_201603a AS agg
+          ON
+            sbj.subject_id = agg.subject_id
+          )
+        AS
+          sbjagg
+        ON
+          cam.id = sbjagg.camera
+        {WHERE}
+      `,
       
       //Select a single camera, mostly for the camera's metadata.
       'selectCameraMetadata': 'SELECT * FROM wildcam_gorongosa_cameras_201601 {WHERE}',

--- a/src/programs/gorongosa/wildcam-gorongosa.map-config.js
+++ b/src/programs/gorongosa/wildcam-gorongosa.map-config.js
@@ -44,7 +44,9 @@ const mapConfig = {
           FROM
             wildcam_gorongosa_subjects_201601_16000 AS sbj
           INNER JOIN
-            wildcam_gorongosa_aggregations_201603a AS agg
+            (
+            SELECT * FROM wildcam_gorongosa_aggregations_201603a WHERE num_classifications >= 5
+            ) AS agg
           ON
             sbj.subject_id = agg.subject_id
           ) AS sbjagg
@@ -83,7 +85,7 @@ const mapConfig = {
             sbj.dateutc AS "date",
             sbj.gorongosa_id,
             agg.species,
-            agg.num_classifications AS "species_count",
+            agg.most_likely_number_of_animals AS "species_count",
             agg.percentage_behaviour_resting AS "percentage_resting",
             agg.percentage_behaviour_standing AS "percentage_standing",
             agg.percentage_behaviour_moving AS "percentage_moving",
@@ -94,7 +96,9 @@ const mapConfig = {
           FROM
             wildcam_gorongosa_subjects_201601_16000 AS sbj
           INNER JOIN
-            wildcam_gorongosa_aggregations_201603a AS agg
+            (
+            SELECT * FROM wildcam_gorongosa_aggregations_201603a WHERE num_classifications >= 5
+            ) AS agg
           ON
             sbj.subject_id = agg.subject_id
           ) AS sbjagg
@@ -128,7 +132,9 @@ const mapConfig = {
           FROM
             wildcam_gorongosa_subjects_201601_16000 AS sbj
           INNER JOIN
-            wildcam_gorongosa_aggregations_201603a AS agg
+            (
+            SELECT * FROM wildcam_gorongosa_aggregations_201603a WHERE num_classifications >= 5
+            ) AS agg
           ON
             sbj.subject_id = agg.subject_id
           ) AS sbjagg
@@ -189,7 +195,9 @@ const mapConfig = {
           FROM
             wildcam_gorongosa_subjects_201601_16000 AS sbj
           INNER JOIN
-            wildcam_gorongosa_aggregations_201603a AS agg
+            (
+            SELECT * FROM wildcam_gorongosa_aggregations_201603a WHERE num_classifications >= 5
+            ) AS agg
           ON
             sbj.subject_id = agg.subject_id
           )


### PR DESCRIPTION
## PR Overview

There are a few errors with WildCam Gorongosa Lab:

1. SQL aggregation selects forgot to implement the `num_classifications >= 5` threshold. This threshold (from the original WildCam Gorongosa Lab) prevents poorly-vetted aggregation results from popping up on the Map Explorer, Downloads results,e tc.
2. `species_count` was being incorrectly mapped to `agg.num_classifications` instead of `agg.most_likely_number_of_animals`. `agg.num_classifications` actually refers to the number of classifications that contributed to the aggregated result, not the number of animals in the image.

This PR fixes these issues, and also expands the view on Gorongosa's SQL queries in the config so it's easier to understand what's going on.

### Status

Merging, but not deploying until Monday.
