### PR TITLE
Reverse spiral and elliptical for export

### DIFF
--- a/src/containers/astro/AstroClassroomsTableContainer.jsx
+++ b/src/containers/astro/AstroClassroomsTableContainer.jsx
@@ -92,14 +92,14 @@ class AstroClassroomsTableContainer extends React.Component {
   }
 
   transformGalaxyDataCsv(csvData) {
-    let csvRows = 'Galaxy ID,Total # of classifications,Spiral,Elliptical,Merger,Artifact,SSDS ID,Image,GZ Original Spiral,GZ Original Elliptical,GZ Original Merger,GZ Original Artifact,Computer Classification\n';
+    let csvRows = 'Galaxy ID,Total # of classifications,Elliptical,Spiral,Merger,Artifact,SSDS ID,Image,GZ Original Elliptical,GZ Original Spiral,GZ Original Merger,GZ Original Artifact,Computer Classification\n';
     const exportData = csvData.data;
     const originalHeaders = exportData.shift();
     const reducerKeyIndex = originalHeaders.indexOf('reducer_key');
     const subjectIdIndex = originalHeaders.indexOf('subject_id');
     const galaxyIdIndex = originalHeaders.indexOf('data.Galaxy Id');
-    const spiralIndex = originalHeaders.indexOf('data.0');
-    const ellipticalIndex = originalHeaders.indexOf('data.1');
+    const ellipticalIndex = originalHeaders.indexOf('data.0');
+    const spiralIndex = originalHeaders.indexOf('data.1');
     const mergerIndex = originalHeaders.indexOf('data.2');
     const artifactIndex = originalHeaders.indexOf('data.3');
     const sdssIdIndex = originalHeaders.indexOf('data.SDSS_ID');
@@ -137,7 +137,7 @@ class AstroClassroomsTableContainer extends React.Component {
           const gzArtifact = metadataRow[gzArtifactIndex];
           const computerClassification = metadataRow[computerClassificationIndex];
 
-          newHumanReadableTable.push([galaxyId, total, spiral, elliptical, merger, artifact, sdssId, image, gzSpiral, gzElliptical, gzMerger, gzArtifact, computerClassification]);
+          newHumanReadableTable.push([galaxyId, total, elliptical, spiral, merger, artifact, sdssId, image, gzElliptical, gzSpiral, gzMerger, gzArtifact, computerClassification]);
         }
       });
     });


### PR DESCRIPTION
We had a report that the header labels in the CSV export for the relaunched Galaxy Zoo activity were reversed. This was confirmed by comparing the tasks from the original project to the new project, that elliptical is now the first choice in the question task list.

Caesar has no knowledge of the human labels for question task answers, so when you get a reducer export, the labels are in array order of the task answer list, like `data0`, `data1`, etc. I take those labels and give them human labels again, `spiral`, `elliptical`, etc. This relabeling is hardcoded and assumed the order of the answers in the task remained the same. This PR fixes the ordering for the new project.

Long term, we should consider a few of options:
1. Zooniverse classrooms requests the workflow from Panoptes to get the human labels.
2. Caesar looks up the Panoptes workflow human labels and stores the labels along side the reduced data or at time of the reduction export
3. The workflow labels could get submitted as part of the classification so Caesar can use them in storing the extract and use it in the reduction as needed and when exports are requested.

Option 1 only benefits GZ project on Zooniverse classrooms (we don't know yet if other classroom projects will need this) and is front-end work. Option 2 or 3 is a broader impact and will take more (back-end) dev time, but possibly of interest to many projects to enhance the exports from Caesar.