### PR TITLE
Fix species_count for Wildcam Gorongosa Lab Map Downloads

### DIFF
--- a/src/programs/gorongosa/wildcam-gorongosa.map-config.js
+++ b/src/programs/gorongosa/wildcam-gorongosa.map-config.js
@@ -631,7 +631,14 @@ function transformGorongosaDownloadData (csvData) {
     
     tgtColumns.forEach(tgtCol => {
       const cellIndex = srcColumns.findIndex(i => i===tgtCol);
-      const cell = (cellIndex >= 0) ? srcRow[cellIndex] : '';
+      let cell = (cellIndex >= 0) ? srcRow[cellIndex] : '';
+      
+      // Special case: species_count
+      // All 'range' values should be translated into arbitrary single values,
+      // to allow mathematical calculations.
+      if (tgtCol === 'species_count' && cell === '11-50') cell = '25';
+      if (tgtCol === 'species_count' && cell === '51+') cell = '75';
+      
       tgtRow.push(cell);
     });
     


### PR DESCRIPTION
## PR Overview

This fixes an issue with the CSV downloads on WildCam Gorongosa's Map Explorer, where `species_count` weren't always giving values in the way that users expect.

- In the CSV download, the `species_count` should always have a _single number value_ (instead of a numerical range) to allow for mathematical calculations, e.g. when processing the data on Excel.
- This means that when `species_count` says `"11-50"`, it should be translated to `"25"`, etc. See https://classroom.zooniverse.org/#/wildcam-gorongosa-lab/explorers/data-guide/ for users expect.

### Status

Mergin' today, deployin' Monday.