### PR TITLE
Add warning for Sign In issues (Oct - Nov 2020?)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2234,7 +2234,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "p-limit": {
@@ -2389,7 +2390,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -4066,7 +4068,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "p-limit": {
@@ -4288,7 +4291,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "schema-utils": {
@@ -6178,7 +6182,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -6368,7 +6373,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "schema-utils": {
@@ -8559,7 +8565,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
@@ -10634,7 +10641,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "normalize-url": {
@@ -12650,6 +12658,20 @@
         "prop-types": "^15.5.10"
       }
     },
+    "react-router": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
+      "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
+      "requires": {
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.3.0",
+        "invariant": "^2.2.2",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.5.4",
+        "warning": "^3.0.0"
+      }
+    },
     "react-router-dom": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
@@ -14004,7 +14026,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -15093,7 +15116,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "schema-utils": {
@@ -16726,7 +16750,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "tapable": {
@@ -16970,7 +16995,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
         "loader-utils": {
@@ -17007,7 +17033,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "semver": {

--- a/src/components/GlobalNotification.jsx
+++ b/src/components/GlobalNotification.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import Box from 'grommet/components/Box';
+import Button from 'grommet/components/Button';
+import Label from 'grommet/components/Label';
+import Paragraph from 'grommet/components/Paragraph';
+
+class GlobalNotification extends React.Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      expand: false,
+      hide: false,
+    }
+  }
+  
+  render () {
+    const { user } = this.props
+    const { expand, hide } = this.state
+    
+    if (hide) return null
+    if (user) return null
+    
+    return (
+      <Box colorIndex="accent-2" pad="small">
+        <Box direction="row">
+          <Paragraph size="small" margin="small">Notice</Paragraph>
+          <Button size="xsmall" onClick={() => { this.setState({ expand: !expand }) }}>[more]</Button>
+          <Button size="xsmall" onClick={() => { this.setState({ hide: true }) }}>[x]</Button>
+        </Box>
+        {expand && (
+          <Paragraph>
+            Full details
+          </Paragraph>
+        )}
+      </Box>
+    )
+  }
+}
+
+GlobalNotification.defaultProps = {
+  user: null
+};
+
+GlobalNotification.propTypes = {
+  user: PropTypes.object
+};
+
+function mapStateToProps(state) {
+  return {
+    user: state.auth.user
+  };
+}
+
+export default connect(mapStateToProps)(GlobalNotification);

--- a/src/components/GlobalNotification.jsx
+++ b/src/components/GlobalNotification.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import Anchor from 'grommet/components/Anchor';
 import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import Label from 'grommet/components/Label';
 import Paragraph from 'grommet/components/Paragraph';
+
+import AlertIcon from 'grommet/components/icons/base/Alert';
 import CloseIcon from 'grommet/components/icons/base/Close';
 import DownIcon from 'grommet/components/icons/base/Down';
 
@@ -32,7 +35,14 @@ class GlobalNotification extends React.Component {
           direction="row"
           pad="none"
         >
-          <Label size="small">Notice</Label>
+          <AlertIcon />
+          <Label
+            size="small"
+          >
+            &nbsp;
+            November 2020: Sign In issues
+            &nbsp;
+          </Label>
           <Button
             icon={<DownIcon size="small" style={{ padding: '4px' }} />}
             onClick={() => { this.setState({ expand: !expand }) }}
@@ -43,9 +53,24 @@ class GlobalNotification extends React.Component {
           />
         </Box>
         {expand && (
-          <Paragraph>
-            Full details
-          </Paragraph>
+          <Box>
+            <Paragraph margin="small" pad="small" size="small" style={{ maxWidth: 'none' }}>
+              We are currently looking into an issue where educators and
+              students cannot login to Zooniverse Classrooms via the Sign In
+              button at the top of this website.
+              We apologise for this inconvenience.
+              While we work on a long term fix, we've found that the following
+              workaround allows users to sign in to Zooniverse Classrooms:
+            </Paragraph>
+            <Paragraph margin="small" pad="small" size="small" style={{ maxWidth: 'none' }}>
+              1. Go to <Anchor href="https://www.zooniverse.org">Zooniverse.org</Anchor>,
+              click on the Sign In button, and proceed to log in.
+            </Paragraph>
+            <Paragraph margin="small" pad="small" size="small" style={{ maxWidth: 'none' }}>
+              2. Once you're logged in at Zooniverse.org, return to this
+              website and click the Sign In button.
+            </Paragraph>
+          </Box>
         )}
       </Box>
     )

--- a/src/components/GlobalNotification.jsx
+++ b/src/components/GlobalNotification.jsx
@@ -5,6 +5,8 @@ import Box from 'grommet/components/Box';
 import Button from 'grommet/components/Button';
 import Label from 'grommet/components/Label';
 import Paragraph from 'grommet/components/Paragraph';
+import CloseIcon from 'grommet/components/icons/base/Close';
+import DownIcon from 'grommet/components/icons/base/Down';
 
 class GlobalNotification extends React.Component {
   constructor(props) {
@@ -24,11 +26,21 @@ class GlobalNotification extends React.Component {
     if (user) return null
     
     return (
-      <Box colorIndex="accent-2" pad="small">
-        <Box direction="row">
-          <Paragraph size="small" margin="small">Notice</Paragraph>
-          <Button size="xsmall" onClick={() => { this.setState({ expand: !expand }) }}>[more]</Button>
-          <Button size="xsmall" onClick={() => { this.setState({ hide: true }) }}>[x]</Button>
+      <Box colorIndex="accent-1" pad="small">
+        <Box
+          align="center"
+          direction="row"
+          pad="none"
+        >
+          <Label size="small">Notice</Label>
+          <Button
+            icon={<DownIcon size="small" style={{ padding: '4px' }} />}
+            onClick={() => { this.setState({ expand: !expand }) }}
+          />
+          <Button
+            icon={<CloseIcon size="small" style={{ padding: '4px' }} />}
+            onClick={() => { this.setState({ hide: true }) }}
+          />
         </Box>
         {expand && (
           <Paragraph>

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -13,6 +13,7 @@ import AppNotification from '../containers/layout/AppNotification';
 import ProgramHomeContainer from '../containers/common/ProgramHomeContainer';
 import JoinPageContainer from '../containers/common/JoinPageContainer';
 import GenericStatusPage from './common/GenericStatusPage';
+import GlobalNotification from './GlobalNotification';
 import GooglePrivacyPolicy from './GooglePrivacyPolicy';
 
 import AppHeader from './layout/AppHeader';
@@ -48,6 +49,7 @@ const Main = ({ admin, initialised, location }) => {
         <AdminLayoutIndicator />}
       <Box>
         <ZooHeader authContainer={<AuthContainer location={location} />} isAdmin={admin} />
+        <GlobalNotification />
         <AppHeader location={location} />
         <AppNotification />
         <Switch>


### PR DESCRIPTION
## PR Overview

Context: there is currently an issue where users cannot login via Oauth on `*.zooniverse.org` websites (such as `classroom.zooniverse.org` - see https://github.com/zooniverse/operations/issues/459). The team is still working on a solution, but in the meantime we need to inform teachers and students about the workaround that allows logging in.

- This PR adds a GeneralNotification component that appears on every page.
  - The GeneralNotification can be manually dismissed (this state is retained until the website is refreshed)
  - The GeneralNotification will NOT appear if the user is already signed in, because they don't need the workaround information
- The General Notification has been updated with a message specific for the recent Sign In issues.

### Status

I'm going ahead and merging + deploying this.