### PR TITLE
Remove Dec 2020 global notifications

### DIFF
--- a/src/components/GlobalNotification.jsx
+++ b/src/components/GlobalNotification.jsx
@@ -40,7 +40,7 @@ class GlobalNotification extends React.Component {
             size="small"
           >
             &nbsp;
-            December 2020: Sign In functionality restored
+            ...
             &nbsp;
           </Label>
           <Button
@@ -55,10 +55,7 @@ class GlobalNotification extends React.Component {
         {expand && (
           <Box>
             <Paragraph margin="small" pad="small" size="small" style={{ maxWidth: 'none' }}>
-              We've recently fixed an issue which prevented educators and students from signing in to Zooniverse Classrooms.
-              Now, if you click on the Sign In button at the top of the website, you should be able to log in with your Zooniverse account like normal.
-              If you're still encountering any problems however, please send an email to contact@zooniverse.org.
-              Thank you for your patience.
+              ...
             </Paragraph>
           </Box>
         )}

--- a/src/components/GlobalNotification.md
+++ b/src/components/GlobalNotification.md
@@ -1,0 +1,28 @@
+## Global Notification component
+
+This component adds a notification to the whole website, usually to inform
+users of some error that's in the process of being fixed.
+
+When necessary, activate the component as follows:
+
+1. update the short and long text in `src/components/GlobalNotification.jsx`
+2. add this component to `src/components/Main.jsx`
+
+```
+  return (
+    <App centered={false} className="app-layout">
+      {admin &&
+        <AdminLayoutIndicator />}
+      <Box>
+        <ZooHeader />
+        <GlobalNotification />  // ADD HERE
+        <AppHeader />
+        <AppNotification />
+        <Switch>
+          ...
+        </Switch>
+        <ZooFooter />
+      </Box>
+    </App>
+  );
+```

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -13,7 +13,6 @@ import AppNotification from '../containers/layout/AppNotification';
 import ProgramHomeContainer from '../containers/common/ProgramHomeContainer';
 import JoinPageContainer from '../containers/common/JoinPageContainer';
 import GenericStatusPage from './common/GenericStatusPage';
-import GlobalNotification from './GlobalNotification';
 import GooglePrivacyPolicy from './GooglePrivacyPolicy';
 
 import AppHeader from './layout/AppHeader';
@@ -49,7 +48,6 @@ const Main = ({ admin, initialised, location }) => {
         <AdminLayoutIndicator />}
       <Box>
         <ZooHeader authContainer={<AuthContainer location={location} />} isAdmin={admin} />
-        <GlobalNotification />
         <AppHeader location={location} />
         <AppNotification />
         <Switch>


### PR DESCRIPTION
## PR Overview

This PR removes the global notification, which was most recently set up in Dec 2020 to inform users of a resolved problem.

- This PR also adds instructions on how to reactivate the Global Notifications should warnings/updates/etc be necessary in the future.